### PR TITLE
Only ignore lib/ folder in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
Super small change. We have subdirectories named lib/ so we shouldn't ignore them