### PR TITLE
Update 'request response get' command to return a valid string

### DIFF
--- a/stoobly_agent/app/cli/request_cli.py
+++ b/stoobly_agent/app/cli/request_cli.py
@@ -244,13 +244,13 @@ def response(ctx):
   help="Retrieve mocked response"
 )
 @click.argument('request_key')
-def get(**kwargs):
+def get(**kwargs) -> None:
   validate_request_key(kwargs['request_key'])
 
   request = RequestFacade(Settings.instance())
   res = __replay(request.mock, kwargs)
 
-  print(res.content)
+  print(res.text)
 
 @response.command(
   help="Query properties in response"
@@ -285,3 +285,4 @@ def __assign_default_alias_resolve_strategy(kwargs):
     # If we have assigned values to aliases, it's likely we want to also have them resolved
     if 'assign' in kwargs and len(kwargs['assign']) > 0 and kwargs['alias_resolve_strategy'] == alias_resolve_strategy.NONE:
         kwargs['alias_resolve_strategy'] = alias_resolve_strategy.FIFO
+

--- a/stoobly_agent/test/app/cli/request/response_test.py
+++ b/stoobly_agent/test/app/cli/request/response_test.py
@@ -34,8 +34,6 @@ class TestResponseGet():
     output = request_result.stdout
     assert type(output) is str
     assert type(output) is not bytes
-    assert isinstance(output, str)
-    assert not isinstance(output, bytes)
 
     # Note: the invoke result's stdout can actually return a string of
     # a byte literal so parse the json for extra validation

--- a/stoobly_agent/test/app/cli/request/response_test.py
+++ b/stoobly_agent/test/app/cli/request/response_test.py
@@ -1,0 +1,45 @@
+import json
+import pdb
+import pytest
+
+from click.testing import CliRunner
+
+from stoobly_agent.test.test_helper import DETERMINISTIC_GET_REQUEST_URL, reset
+
+from stoobly_agent.cli import record, request
+from stoobly_agent.lib.orm.request import Request
+
+@pytest.fixture(scope='module')
+def runner():
+  return CliRunner()
+
+@pytest.fixture(autouse=True, scope='module')
+def settings():
+  return reset()
+
+class TestResponseGet():
+
+  @pytest.fixture(autouse=True, scope='class')
+  def request_create_cli_result(self, runner: CliRunner):
+    record_result = runner.invoke(record, [DETERMINISTIC_GET_REQUEST_URL])
+    assert record_result.exit_code == 0
+    return record_result
+
+  def test_it_returns_correct_response(self, runner: CliRunner):
+    _request = Request.last()
+
+    request_result = runner.invoke(request, ['response', 'get', _request.key()])
+    assert request_result.exit_code == 0
+
+    output = request_result.stdout
+    assert type(output) is str
+    assert type(output) is not bytes
+    assert isinstance(output, str)
+    assert not isinstance(output, bytes)
+
+    # Note: the invoke result's stdout can actually return a string of
+    # a byte literal so parse the json for extra validation
+    json_response = json.loads(output)
+    assert json_response['message'] is not None
+    assert json_response['status'] == 'success'
+

--- a/stoobly_agent/test/app/models/schemas/request_test.py
+++ b/stoobly_agent/test/app/models/schemas/request_test.py
@@ -32,3 +32,4 @@ class TestRequest():
 
   def test_headers(self, stoobly_request: Request):
     assert stoobly_request.headers['content-length'] == '0'
+


### PR DESCRIPTION
Resolves https://github.com/Stoobly/stoobly-agent/issues/101

`.text` is to return the [content of the server's response](https://docs.python-requests.org/en/latest/user/quickstart/#response-content) with an educated guess on the encoding from the HTTP headers. Whereas `.content` is for the [response body as bytes](https://docs.python-requests.org/en/latest/user/quickstart/#binary-response-content)

Before the bug fix:
```
$ stoobly-agent request response get REQUEST_ID

b'[{"key":"val"},{"key2":"val2"}]'
```

After the bug fix:
```
$ stoobly-agent request response get REQUEST_ID

[{"key":"val"},{"key2":"val2"}]
```