### PR TITLE
Stop searching for data directory at root

### DIFF
--- a/stoobly_agent/config/data_dir.py
+++ b/stoobly_agent/config/data_dir.py
@@ -136,7 +136,14 @@ class DataDir:
             os.mkdir(self.__data_dir_path)
 
     def find_data_dir(self, start_path: str) -> str:
-        while start_path != os.path.expanduser("~"):
+        # Note: these paths won't work for Windows
+        root_dir = os.path.abspath(os.sep)
+        home_dir = os.path.expanduser("~")
+
+        while start_path != home_dir:
+            if start_path == root_dir:
+                start_path = home_dir
+
             data_dir_path = os.path.join(start_path, self.DATA_DIR_NAME)
 
             if os.path.exists(data_dir_path):


### PR DESCRIPTION
When root directory is reached and data directory still not found, default to looking in the home directory