### PR TITLE
OAS Import Command for Stoobly CLI #212

### DIFF
--- a/stoobly_agent/app/cli/endpoint_cli.py
+++ b/stoobly_agent/app/cli/endpoint_cli.py
@@ -74,6 +74,9 @@ def import_endpoint(**kwargs):
 
   endpoint_handler = lambda endpoint: print(f"{bcolors.OKBLUE}Importing Endpoint: {endpoint['method']} {endpoint['path']}{bcolors.ENDC}")
   context.with_endpoint_handler(endpoint_handler)
+
+  error_handler = lambda endpoint: print(f"{bcolors.FAIL}Failed to Import Endpoint: {endpoint['method']} {endpoint['path']} - Aborting Operation{bcolors.ENDC}")
+  context.with_error_handler(error_handler)
   
   facade = EndpointFacade(settings)
   facade.import_endpoints(context)

--- a/stoobly_agent/app/cli/endpoint_cli.py
+++ b/stoobly_agent/app/cli/endpoint_cli.py
@@ -1,4 +1,4 @@
-import click
+import click, sys
 
 from stoobly_agent.app.models.types import OPENAPI_FORMAT
 from stoobly_agent.app.settings import Settings
@@ -74,9 +74,6 @@ def import_endpoint(**kwargs):
 
   endpoint_handler = lambda endpoint: print(f"{bcolors.OKBLUE}Importing Endpoint: {endpoint['method']} {endpoint['path']}{bcolors.ENDC}")
   context.with_endpoint_handler(endpoint_handler)
-
-  error_handler = lambda endpoint: print(f"{bcolors.FAIL}Failed to Import Endpoint: {endpoint['method']} {endpoint['path']} - Aborting Operation{bcolors.ENDC}")
-  context.with_error_handler(error_handler)
   
   facade = EndpointFacade(settings)
   facade.import_endpoints(context)

--- a/stoobly_agent/app/cli/helpers/endpoint_facade.py
+++ b/stoobly_agent/app/cli/helpers/endpoint_facade.py
@@ -12,7 +12,7 @@ from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderN
 from .endpoints_apply_context import EndpointsApplyContext
 from .endpoints_import_context import EndpointsImportContext
 from .endpoints_apply_service import apply_endpoints
-from .endpoints_import_service import import_all_endpoints
+from .endpoints_import_service import import_endpoints
 from .synchronize_request_service import SynchronizeRequestService
 
 class EndpointFacade():
@@ -43,4 +43,4 @@ class EndpointFacade():
     context.with_response_param_name_resource(ResponseParamNamesResource(api_url, api_key))
     context.with_response_header_name_resource(ResponseHeaderNamesResource(api_url, api_key))
 
-    import_all_endpoints(context)
+    import_endpoints(context)

--- a/stoobly_agent/app/cli/helpers/endpoint_facade.py
+++ b/stoobly_agent/app/cli/helpers/endpoint_facade.py
@@ -2,9 +2,17 @@ import pdb
 
 from stoobly_agent.app.models.factories.resource.request import RequestResourceFactory
 from stoobly_agent.app.settings import Settings
+from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
+from stoobly_agent.lib.api.header_names_resource import HeaderNamesResource
+from stoobly_agent.lib.api.body_param_names_resource import BodyParamNamesResource
+from stoobly_agent.lib.api.query_param_names_resource import QueryParamNamesResource
+from stoobly_agent.lib.api.response_param_names_resource import ResponseParamNamesResource
+from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderNamesResource
 
 from .endpoints_apply_context import EndpointsApplyContext
+from .endpoints_import_context import EndpointsImportContext
 from .endpoints_apply_service import apply_endpoints
+from .endpoints_import_service import import_all_endpoints
 from .synchronize_request_service import SynchronizeRequestService
 
 class EndpointFacade():
@@ -23,3 +31,16 @@ class EndpointFacade():
     context.with_request_handler(request_handler)
 
     apply_endpoints(context)
+  
+  def import_endpoints(self, context: EndpointsImportContext):
+    api_url = self.__settings.remote.api_url
+    api_key = self.__settings.remote.api_key
+
+    context.with_endpoint_resource(EndpointsResource(api_url, api_key))
+    context.with_header_name_resource(HeaderNamesResource(api_url, api_key))
+    context.with_body_param_name_resource(BodyParamNamesResource(api_url, api_key))
+    context.with_query_param_name_resource(QueryParamNamesResource(api_url, api_key))
+    context.with_response_param_name_resource(ResponseParamNamesResource(api_url, api_key))
+    context.with_response_header_name_resource(ResponseHeaderNamesResource(api_url, api_key))
+
+    import_all_endpoints(context)

--- a/stoobly_agent/app/cli/helpers/endpoints_import_context.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_context.py
@@ -1,31 +1,29 @@
-from typing import Callable
+from typing import Callable, TypedDict
 
+from .openapi_endpoint_adapter import OpenApiEndpointAdapter
+from stoobly_agent.app.models.types import OPENAPI_FORMAT
+from stoobly_agent.lib.api.body_param_names_resource import BodyParamNamesResource
 from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
 from stoobly_agent.lib.api.header_names_resource import HeaderNamesResource
-from stoobly_agent.lib.api.body_param_names_resource import BodyParamNamesResource
+from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
 from stoobly_agent.lib.api.query_param_names_resource import QueryParamNamesResource
 from stoobly_agent.lib.api.response_param_names_resource import ResponseParamNamesResource
 from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderNamesResource
-from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
-from stoobly_agent.app.models.types import OPENAPI_FORMAT
-
-from .openapi_endpoint_adapter import OpenApiEndpointAdapter
 
 class EndpointsImportContext:
-
   def __init__(self):
     self.endpoints = []
     self.endpoint_handlers = []
-    self.endpoint_resource = None
-    self.header_name_resource = None
-    self.body_param_name_resource = None
-    self.query_param_name_resource = None
-    self.response_param_name_resource = None
-    self.response_header_name_resource = None
+    self.error_handlers = []
+    self.resources = {}
     self.project_id = None
 
   def with_endpoint_handler(self, handler: Callable[[EndpointShowResponse], None]):
     self.endpoint_handlers.append(handler)
+    return self
+  
+  def with_error_handler(self, handler: Callable[[EndpointShowResponse], None]):
+    self.error_handlers.append(handler)
     return self
   
   def with_project(self, project_id: int):
@@ -33,27 +31,27 @@ class EndpointsImportContext:
     return self
   
   def with_endpoint_resource(self, resource: EndpointsResource):
-    self.endpoint_resource = resource
+    self.resources['endpoint'] = resource
     return self
   
   def with_header_name_resource(self, resource: HeaderNamesResource):
-    self.header_name_resource = resource
+    self.resources['header_name'] = resource
     return self
 
   def with_body_param_name_resource(self, resource: BodyParamNamesResource):
-    self.body_param_name_resource = resource
+    self.resources['body_param_name'] = resource
     return self
 
   def with_query_param_name_resource(self, resource: QueryParamNamesResource):
-    self.query_param_name_resource = resource
+    self.resources['query_param_name'] = resource
     return self
 
   def with_response_param_name_resource(self, resource: ResponseParamNamesResource):
-    self.response_param_name_resource = resource
+    self.resources['response_param_name'] = resource
     return self
   
   def with_response_header_name_resource(self, resource: ResponseHeaderNamesResource):
-    self.response_header_name_resource = resource
+    self.resources['response_header_name'] = resource
     return self
 
   def with_source(self, path: str, format: str):

--- a/stoobly_agent/app/cli/helpers/endpoints_import_context.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_context.py
@@ -1,0 +1,64 @@
+from typing import Callable
+
+from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
+from stoobly_agent.lib.api.header_names_resource import HeaderNamesResource
+from stoobly_agent.lib.api.body_param_names_resource import BodyParamNamesResource
+from stoobly_agent.lib.api.query_param_names_resource import QueryParamNamesResource
+from stoobly_agent.lib.api.response_param_names_resource import ResponseParamNamesResource
+from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderNamesResource
+from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
+from stoobly_agent.app.models.types import OPENAPI_FORMAT
+
+from .openapi_endpoint_adapter import OpenApiEndpointAdapter
+
+class EndpointsImportContext:
+
+  def __init__(self):
+    self.endpoints = []
+    self.endpoint_handlers = []
+    self.endpoint_resource = None
+    self.header_name_resource = None
+    self.body_param_name_resource = None
+    self.query_param_name_resource = None
+    self.response_param_name_resource = None
+    self.response_header_name_resource = None
+    self.project_id = None
+
+  def with_endpoint_handler(self, handler: Callable[[EndpointShowResponse], None]):
+    self.endpoint_handlers.append(handler)
+    return self
+  
+  def with_project(self, project_id: int):
+    self.project_id = project_id
+    return self
+  
+  def with_endpoint_resource(self, resource: EndpointsResource):
+    self.endpoint_resource = resource
+    return self
+  
+  def with_header_name_resource(self, resource: HeaderNamesResource):
+    self.header_name_resource = resource
+    return self
+
+  def with_body_param_name_resource(self, resource: BodyParamNamesResource):
+    self.body_param_name_resource = resource
+    return self
+
+  def with_query_param_name_resource(self, resource: QueryParamNamesResource):
+    self.query_param_name_resource = resource
+    return self
+
+  def with_response_param_name_resource(self, resource: ResponseParamNamesResource):
+    self.response_param_name_resource = resource
+    return self
+  
+  def with_response_header_name_resource(self, resource: ResponseHeaderNamesResource):
+    self.response_header_name_resource = resource
+    return self
+
+  def with_source(self, path: str, format: str):
+    if format == OPENAPI_FORMAT:
+      endpoint_adapter = OpenApiEndpointAdapter()
+      self.endpoints += endpoint_adapter.adapt_from_file(path)
+
+    return self

--- a/stoobly_agent/app/cli/helpers/endpoints_import_context.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_context.py
@@ -14,16 +14,11 @@ class EndpointsImportContext:
   def __init__(self):
     self.endpoints = []
     self.endpoint_handlers = []
-    self.error_handlers = []
     self.resources = {}
     self.project_id = None
 
   def with_endpoint_handler(self, handler: Callable[[EndpointShowResponse], None]):
     self.endpoint_handlers.append(handler)
-    return self
-  
-  def with_error_handler(self, handler: Callable[[EndpointShowResponse], None]):
-    self.error_handlers.append(handler)
     return self
   
   def with_project(self, project_id: int):

--- a/stoobly_agent/app/cli/helpers/endpoints_import_service.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_service.py
@@ -1,6 +1,7 @@
 import json
 import requests
-from typing import TypedDict
+import sys
+from typing import Dict
 
 from .endpoints_import_context import EndpointsImportContext
 from stoobly_agent.app.models.types import ENDPOINT_COMPONENT_NAMES
@@ -13,27 +14,32 @@ from stoobly_agent.lib.api.interfaces.endpoints import RequestComponentName
 from stoobly_agent.lib.api.query_param_names_resource import QueryParamNamesResource
 from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderNamesResource
 from stoobly_agent.lib.api.response_param_names_resource import ResponseParamNamesResource
-
-class PendingImportArgs(TypedDict):
-    project_id: int
-    endpoint_id: int
-    component_name: str
-    component: RequestComponentName
-    component_resource_class: EndpointsResource
+from stoobly_agent.lib.logger import bcolors
 
 def import_endpoints(context: EndpointsImportContext):
-    uploaded_endpoints = []
     for endpoint in context.endpoints:
         for endpoint_handler in context.endpoint_handlers:
             endpoint_handler(endpoint)
 
-        res = import_endpoint_and_component_name(context, endpoint, uploaded_endpoints)
-        if not res.ok:
-            for error_handler in context.error_handlers:
-                error_handler(endpoint)
-            cleanup_endpoints(context.project_id, context.resources['endpoint'], uploaded_endpoints)
-            raise AssertionError(res.content)
+        try:
+            res = import_endpoint(context.project_id, context.resources['endpoint'], endpoint)
+        except requests.HTTPError as e:
+            error_handler(endpoint, e)
+            return
+        
+        if res.status_code == 409: # Endpoint already created
+            continue
 
+        endpoint_id = res.json()['id']
+        try:
+            res = import_component_names(context.project_id, endpoint_id, endpoint, context.resources)
+        except requests.HTTPError as e:
+            error_handler(endpoint, e)
+            try:
+                cleanup_endpoint(context.project_id, endpoint_id, context.resources['endpoint'])
+            except requests.HTTPError as e:
+                print(f"{bcolors.FAIL}Encountered {e.response.status_code} {e.response.reason}: {e.response.text} - Failed to delete endpoint: {endpoint['method']} {endpoint['path']}{bcolors.ENDC}", file=sys.stderr)
+            return
 
 def import_endpoint(project_id: int, endpoint_resource: EndpointsResource, endpoint: EndpointShowResponse):
     res: requests.Response = endpoint_resource.create(**{
@@ -44,11 +50,14 @@ def import_endpoint(project_id: int, endpoint_resource: EndpointsResource, endpo
         'port': endpoint.get('port'),
         'project_id': project_id,
     })
+
+    if res.ok or res.status_code == 409: # Endpoint already created
+        return res
     
-    return res
+    res.raise_for_status()
 
 def import_header_name(project_id: int, endpoint_id: int, header_name_resource: HeaderNamesResource, header_name: RequestComponentName): 
-    res: requests.Response = header_name_resource.create(**{
+    res: requests.Response = header_name_resource.create(endpoint_id, {
         'name': header_name.get('name'),
         'is_deterministic': header_name.get('is_deterministic', True),
         'is_required': header_name.get('is_required', False),
@@ -56,10 +65,10 @@ def import_header_name(project_id: int, endpoint_id: int, header_name_resource: 
         'project_id': project_id,  
     })
 
-    return res
+    res.raise_for_status()
 
 def import_body_param_name(project_id: int, endpoint_id: int, body_param_name_resource: BodyParamNamesResource, body_param_name: BodyParamName):
-    res: requests.Response = body_param_name_resource.create(**{
+    res: requests.Response = body_param_name_resource.create(endpoint_id, {
         'name': body_param_name.get('name'),
         'is_deterministic': body_param_name.get('is_deterministic', True),
         'is_required': body_param_name.get('is_required', False),
@@ -69,10 +78,10 @@ def import_body_param_name(project_id: int, endpoint_id: int, body_param_name_re
         'project_id': project_id,
     })
 
-    return res
+    res.raise_for_status()
 
 def import_query_param_name(project_id: int, endpoint_id: int, query_param_name_resource: QueryParamNamesResource, query_param_name: RequestComponentName):
-    res: requests.Response = query_param_name_resource.create(**{
+    res: requests.Response = query_param_name_resource.create(endpoint_id, {
         'name': query_param_name.get('name'),
         'is_deterministic': query_param_name.get('is_deterministic', True),
         'is_required': query_param_name.get('is_required', False),
@@ -80,10 +89,10 @@ def import_query_param_name(project_id: int, endpoint_id: int, query_param_name_
         'project_id': project_id,
     })
 
-    return res
+    res.raise_for_status()
 
 def import_response_param_name(project_id: int, endpoint_id: int, response_param_name_resource: ResponseParamNamesResource, response_param_name: RequestComponentName):
-    res: requests.Response = response_param_name_resource.create(**{
+    res: requests.Response = response_param_name_resource.create(endpoint_id, {
         'name': response_param_name.get('name'),
         'is_deterministic': response_param_name.get('is_deterministic', True),
         'is_required': response_param_name.get('is_required', False),
@@ -93,10 +102,10 @@ def import_response_param_name(project_id: int, endpoint_id: int, response_param
         'project_id': project_id,
     })
 
-    return res
+    res.raise_for_status()
 
 def import_response_header_name(project_id: int, endpoint_id: int, response_header_name_resource: ResponseHeaderNamesResource, response_header_name: RequestComponentName):
-    res: requests.Response = response_header_name_resource.create(**{
+    res: requests.Response = response_header_name_resource.create(endpoint_id, {
         'name': response_header_name.get('name'),
         'is_deterministic': response_header_name.get('is_deterministic', True),
         'is_required': response_header_name.get('is_required', False),
@@ -104,50 +113,35 @@ def import_response_header_name(project_id: int, endpoint_id: int, response_head
         'project_id': project_id,  
     })
 
-    return res
+    res.raise_for_status()
 
 component_name_import_dispatch = {
-    'header_name': import_header_name,
-    'body_param_name': import_body_param_name,
-    'query_param_name': import_query_param_name,
-    'response_param_name': import_response_param_name,
-    'response_header_name': import_response_header_name
+    ENDPOINT_COMPONENT_NAMES[0]: import_header_name,
+    ENDPOINT_COMPONENT_NAMES[1]: import_body_param_name,
+    ENDPOINT_COMPONENT_NAMES[2]: import_query_param_name,
+    ENDPOINT_COMPONENT_NAMES[3]: import_response_header_name,
+    ENDPOINT_COMPONENT_NAMES[4]: import_response_param_name
 }
 
-def process_import(args: PendingImportArgs):
-    return component_name_import_dispatch[args['component_name']](args['project_id'], args['endpoint_id'], args['component_resource_class'], args['component'])
+def process_import(component_name: str, *args):
+    return component_name_import_dispatch[component_name](*args)
 
-def import_endpoint_and_component_name(context: EndpointsImportContext, endpoint: EndpointShowResponse, uploaded_endpoints):
-    res = import_endpoint(context.project_id, context.resources['endpoint'], endpoint)
-
-    if not res.ok:
-        return res
-
-    endpoint_id = res.json()['id']
-    uploaded_endpoints.append(endpoint_id)
-    import_queue = []
+def import_component_names(project_id: int, endpoint_id: int, endpoint: EndpointShowResponse, resources: Dict[str, EndpointsResource]):
     for component_name in ENDPOINT_COMPONENT_NAMES:
         for component in endpoint.get(f'{component_name}s', {}):
-            resource = context.resources[component_name]
-            pending_import: PendingImportArgs = {
-                'project_id': context.project_id,
-                'endpoint_id': endpoint_id,
-                'component_name': component_name,
-                'component': component,
-                'component_resource_class': resource
-            }
-            import_queue.append(pending_import)
-    
-    while res.ok and len(import_queue) > 0:
-        pending_import = import_queue.pop()
-        res = process_import(pending_import)
-    
-    return res
+            resource = resources[component_name]
+            process_import(component_name, project_id, endpoint_id, resource, component)
 
-def cleanup_endpoints(project_id: int, resource: EndpointsResource, uploaded_endpoints):
-    for endpoint_id in uploaded_endpoints:
-        res: requests.Response = resource.destroy(endpoint_id, **{
-            'project_id': project_id
-        })
+def cleanup_endpoint(project_id: int, endpoint_id: int, resource: EndpointsResource):
+    print(f"{bcolors.FAIL}Cleaning up partial import...{bcolors.ENDC}")
+    res: requests.Response = resource.destroy(endpoint_id, **{
+        'project_id': project_id
+    })
 
-        res.raise_for_status()
+    res.raise_for_status()
+
+def error_handler(endpoint: EndpointShowResponse, error: requests.HTTPError):
+    print(
+        f"{bcolors.FAIL}Encountered {error.response.status_code} {error.response.reason}: {error.response.text} - Failed to import endpoint: {endpoint['method']} {endpoint['path']} - Aborting operation{bcolors.ENDC}", 
+        file=sys.stderr
+    )

--- a/stoobly_agent/app/cli/helpers/endpoints_import_service.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_service.py
@@ -1,0 +1,123 @@
+import requests
+import json
+
+from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
+from stoobly_agent.lib.api.interfaces.endpoints import RequestComponentName
+from stoobly_agent.lib.api.interfaces.endpoints import BodyParamName
+from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
+
+from .endpoints_import_context import EndpointsImportContext
+
+def import_all_endpoints(context: EndpointsImportContext):
+    for endpoint in context.endpoints:
+        for endpoint_handler in context.endpoint_handlers:
+            endpoint_handler(endpoint)
+
+        import_endpoint_and_component_name_resources(context, endpoint)
+
+def import_endpoint_and_component_name_resources(context: EndpointsImportContext, endpoint: EndpointShowResponse):
+    res = import_endpoint(context, endpoint)
+
+    endpoint_id = res['id']
+    if endpoint.get('header_names'):
+        for header_name in endpoint['header_names']:
+            import_header_name(context, endpoint_id, header_name)
+    
+    if endpoint.get('body_param_names'):
+        for body_param_name in endpoint['body_param_names']:
+            import_body_param_name(context, endpoint_id, body_param_name)
+
+    if endpoint.get('query_param_names'):
+        for query_param_name in endpoint['query_param_names']:
+            import_query_param_name(context, endpoint_id, query_param_name)
+    
+    if endpoint.get('response_param_names'):
+        for response_param_name in endpoint['response_param_names']:
+            import_response_param_name(context, endpoint_id, response_param_name)
+
+    if endpoint.get('response_header_names'):
+        for response_header_name in endpoint['response_header_names']:
+            import_response_header_name(context, endpoint_id, response_header_name)
+    
+def import_endpoint(context: EndpointsImportContext, endpoint: EndpointShowResponse):
+    res: requests.Response = context.endpoint_resource.create(**{
+        'host': endpoint.get('host'),
+        'method': endpoint.get('method'),
+        'path_segments': json.dumps(endpoint.get('path_segment_names', [])),
+        'path': endpoint.get('path'),
+        'port': endpoint.get('port'),
+        'project_id': context.project_id,
+    })
+
+    res.raise_for_status()
+    
+    return res.json()
+
+def import_header_name(context: EndpointsImportContext, endpoint_id: int, header_name: RequestComponentName): 
+    res: requests.Response = context.header_name_resource.create(**{
+        'name': header_name.get('name'),
+        'is_deterministic': header_name.get('is_deterministic', True),
+        'is_required': header_name.get('is_required', False),
+        'endpoint_id': endpoint_id,
+        'project_id': context.project_id,  
+    })
+
+    res.raise_for_status()
+
+    return res.json()
+
+def import_body_param_name(context: EndpointsImportContext, endpoint_id: int,  body_param_name: BodyParamName):
+    res: requests.Response = context.body_param_name_resource.create(**{
+        'name': body_param_name.get('name'),
+        'is_deterministic': body_param_name.get('is_deterministic', True),
+        'is_required': body_param_name.get('is_required', False),
+        'inferred_type': body_param_name.get('inferred_type'),
+        'query': body_param_name.get('query'),
+        'endpoint_id': endpoint_id,
+        'project_id': context.project_id,
+    })
+
+    res.raise_for_status()
+
+    return res.json()
+
+def import_query_param_name(context: EndpointsImportContext, endpoint_id: int, query_param_name: RequestComponentName):
+    res: requests.Response = context.query_param_name_resource.create(**{
+        'name': query_param_name.get('name'),
+        'is_deterministic': query_param_name.get('is_deterministic', True),
+        'is_required': query_param_name.get('is_required', False),
+        'endpoint_id': endpoint_id,
+        'project_id': context.project_id,
+    })
+
+    res.raise_for_status()
+
+    return res.json()
+
+def import_response_param_name(context: EndpointsImportContext, endpoint_id: int, response_param_name: RequestComponentName):
+    res: requests.Response = context.response_param_name_resource.create(**{
+        'name': response_param_name.get('name'),
+        'is_deterministic': response_param_name.get('is_deterministic', True),
+        'is_required': response_param_name.get('is_required', False),
+        'inferred_type': response_param_name.get('inferred_type'),
+        'query': response_param_name.get('query'),
+        'endpoint_id': endpoint_id,
+        'project_id': context.project_id,
+    })
+
+    res.raise_for_status()
+
+    return res.json()
+
+def import_response_header_name(context: EndpointsImportContext, endpoint_id: int, response_header_name: RequestComponentName):
+    res: requests.Response = context.response_header_name_resource.create(**{
+        'name': response_header_name.get('name'),
+        'is_deterministic': response_header_name.get('is_deterministic', True),
+        'is_required': response_header_name.get('is_required', False),
+        'endpoint_id': endpoint_id,
+        'project_id': context.project_id,  
+    })
+
+    res.raise_for_status()
+
+    return res.json()

--- a/stoobly_agent/app/cli/helpers/endpoints_import_service.py
+++ b/stoobly_agent/app/cli/helpers/endpoints_import_service.py
@@ -1,123 +1,153 @@
-import requests
 import json
-
-from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
-from stoobly_agent.lib.api.interfaces.endpoints import RequestComponentName
-from stoobly_agent.lib.api.interfaces.endpoints import BodyParamName
-from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
+import requests
+from typing import TypedDict
 
 from .endpoints_import_context import EndpointsImportContext
+from stoobly_agent.app.models.types import ENDPOINT_COMPONENT_NAMES
+from stoobly_agent.lib.api.body_param_names_resource import BodyParamNamesResource
+from stoobly_agent.lib.api.endpoints_resource import EndpointsResource
+from stoobly_agent.lib.api.header_names_resource import HeaderNamesResource
+from stoobly_agent.lib.api.interfaces.endpoints import BodyParamName
+from stoobly_agent.lib.api.interfaces.endpoints import EndpointShowResponse
+from stoobly_agent.lib.api.interfaces.endpoints import RequestComponentName
+from stoobly_agent.lib.api.query_param_names_resource import QueryParamNamesResource
+from stoobly_agent.lib.api.response_header_names_resource import ResponseHeaderNamesResource
+from stoobly_agent.lib.api.response_param_names_resource import ResponseParamNamesResource
 
-def import_all_endpoints(context: EndpointsImportContext):
+class PendingImportArgs(TypedDict):
+    project_id: int
+    endpoint_id: int
+    component_name: str
+    component: RequestComponentName
+    component_resource_class: EndpointsResource
+
+def import_endpoints(context: EndpointsImportContext):
+    uploaded_endpoints = []
     for endpoint in context.endpoints:
         for endpoint_handler in context.endpoint_handlers:
             endpoint_handler(endpoint)
 
-        import_endpoint_and_component_name_resources(context, endpoint)
+        res = import_endpoint_and_component_name(context, endpoint, uploaded_endpoints)
+        if not res.ok:
+            for error_handler in context.error_handlers:
+                error_handler(endpoint)
+            cleanup_endpoints(context.project_id, context.resources['endpoint'], uploaded_endpoints)
+            raise AssertionError(res.content)
 
-def import_endpoint_and_component_name_resources(context: EndpointsImportContext, endpoint: EndpointShowResponse):
-    res = import_endpoint(context, endpoint)
 
-    endpoint_id = res['id']
-    if endpoint.get('header_names'):
-        for header_name in endpoint['header_names']:
-            import_header_name(context, endpoint_id, header_name)
-    
-    if endpoint.get('body_param_names'):
-        for body_param_name in endpoint['body_param_names']:
-            import_body_param_name(context, endpoint_id, body_param_name)
-
-    if endpoint.get('query_param_names'):
-        for query_param_name in endpoint['query_param_names']:
-            import_query_param_name(context, endpoint_id, query_param_name)
-    
-    if endpoint.get('response_param_names'):
-        for response_param_name in endpoint['response_param_names']:
-            import_response_param_name(context, endpoint_id, response_param_name)
-
-    if endpoint.get('response_header_names'):
-        for response_header_name in endpoint['response_header_names']:
-            import_response_header_name(context, endpoint_id, response_header_name)
-    
-def import_endpoint(context: EndpointsImportContext, endpoint: EndpointShowResponse):
-    res: requests.Response = context.endpoint_resource.create(**{
+def import_endpoint(project_id: int, endpoint_resource: EndpointsResource, endpoint: EndpointShowResponse):
+    res: requests.Response = endpoint_resource.create(**{
         'host': endpoint.get('host'),
         'method': endpoint.get('method'),
         'path_segments': json.dumps(endpoint.get('path_segment_names', [])),
         'path': endpoint.get('path'),
         'port': endpoint.get('port'),
-        'project_id': context.project_id,
+        'project_id': project_id,
     })
-
-    res.raise_for_status()
     
-    return res.json()
+    return res
 
-def import_header_name(context: EndpointsImportContext, endpoint_id: int, header_name: RequestComponentName): 
-    res: requests.Response = context.header_name_resource.create(**{
+def import_header_name(project_id: int, endpoint_id: int, header_name_resource: HeaderNamesResource, header_name: RequestComponentName): 
+    res: requests.Response = header_name_resource.create(**{
         'name': header_name.get('name'),
         'is_deterministic': header_name.get('is_deterministic', True),
         'is_required': header_name.get('is_required', False),
         'endpoint_id': endpoint_id,
-        'project_id': context.project_id,  
+        'project_id': project_id,  
     })
 
-    res.raise_for_status()
+    return res
 
-    return res.json()
-
-def import_body_param_name(context: EndpointsImportContext, endpoint_id: int,  body_param_name: BodyParamName):
-    res: requests.Response = context.body_param_name_resource.create(**{
+def import_body_param_name(project_id: int, endpoint_id: int, body_param_name_resource: BodyParamNamesResource, body_param_name: BodyParamName):
+    res: requests.Response = body_param_name_resource.create(**{
         'name': body_param_name.get('name'),
         'is_deterministic': body_param_name.get('is_deterministic', True),
         'is_required': body_param_name.get('is_required', False),
         'inferred_type': body_param_name.get('inferred_type'),
         'query': body_param_name.get('query'),
         'endpoint_id': endpoint_id,
-        'project_id': context.project_id,
+        'project_id': project_id,
     })
 
-    res.raise_for_status()
+    return res
 
-    return res.json()
-
-def import_query_param_name(context: EndpointsImportContext, endpoint_id: int, query_param_name: RequestComponentName):
-    res: requests.Response = context.query_param_name_resource.create(**{
+def import_query_param_name(project_id: int, endpoint_id: int, query_param_name_resource: QueryParamNamesResource, query_param_name: RequestComponentName):
+    res: requests.Response = query_param_name_resource.create(**{
         'name': query_param_name.get('name'),
         'is_deterministic': query_param_name.get('is_deterministic', True),
         'is_required': query_param_name.get('is_required', False),
         'endpoint_id': endpoint_id,
-        'project_id': context.project_id,
+        'project_id': project_id,
     })
 
-    res.raise_for_status()
+    return res
 
-    return res.json()
-
-def import_response_param_name(context: EndpointsImportContext, endpoint_id: int, response_param_name: RequestComponentName):
-    res: requests.Response = context.response_param_name_resource.create(**{
+def import_response_param_name(project_id: int, endpoint_id: int, response_param_name_resource: ResponseParamNamesResource, response_param_name: RequestComponentName):
+    res: requests.Response = response_param_name_resource.create(**{
         'name': response_param_name.get('name'),
         'is_deterministic': response_param_name.get('is_deterministic', True),
         'is_required': response_param_name.get('is_required', False),
         'inferred_type': response_param_name.get('inferred_type'),
         'query': response_param_name.get('query'),
         'endpoint_id': endpoint_id,
-        'project_id': context.project_id,
+        'project_id': project_id,
     })
 
-    res.raise_for_status()
+    return res
 
-    return res.json()
-
-def import_response_header_name(context: EndpointsImportContext, endpoint_id: int, response_header_name: RequestComponentName):
-    res: requests.Response = context.response_header_name_resource.create(**{
+def import_response_header_name(project_id: int, endpoint_id: int, response_header_name_resource: ResponseHeaderNamesResource, response_header_name: RequestComponentName):
+    res: requests.Response = response_header_name_resource.create(**{
         'name': response_header_name.get('name'),
         'is_deterministic': response_header_name.get('is_deterministic', True),
         'is_required': response_header_name.get('is_required', False),
         'endpoint_id': endpoint_id,
-        'project_id': context.project_id,  
+        'project_id': project_id,  
     })
 
-    res.raise_for_status()
+    return res
 
-    return res.json()
+component_name_import_dispatch = {
+    'header_name': import_header_name,
+    'body_param_name': import_body_param_name,
+    'query_param_name': import_query_param_name,
+    'response_param_name': import_response_param_name,
+    'response_header_name': import_response_header_name
+}
+
+def process_import(args: PendingImportArgs):
+    return component_name_import_dispatch[args['component_name']](args['project_id'], args['endpoint_id'], args['component_resource_class'], args['component'])
+
+def import_endpoint_and_component_name(context: EndpointsImportContext, endpoint: EndpointShowResponse, uploaded_endpoints):
+    res = import_endpoint(context.project_id, context.resources['endpoint'], endpoint)
+
+    if not res.ok:
+        return res
+
+    endpoint_id = res.json()['id']
+    uploaded_endpoints.append(endpoint_id)
+    import_queue = []
+    for component_name in ENDPOINT_COMPONENT_NAMES:
+        for component in endpoint.get(f'{component_name}s', {}):
+            resource = context.resources[component_name]
+            pending_import: PendingImportArgs = {
+                'project_id': context.project_id,
+                'endpoint_id': endpoint_id,
+                'component_name': component_name,
+                'component': component,
+                'component_resource_class': resource
+            }
+            import_queue.append(pending_import)
+    
+    while res.ok and len(import_queue) > 0:
+        pending_import = import_queue.pop()
+        res = process_import(pending_import)
+    
+    return res
+
+def cleanup_endpoints(project_id: int, resource: EndpointsResource, uploaded_endpoints):
+    for endpoint_id in uploaded_endpoints:
+        res: requests.Response = resource.destroy(endpoint_id, **{
+            'project_id': project_id
+        })
+
+        res.raise_for_status()

--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -257,6 +257,7 @@ class OpenApiEndpointAdapter():
           for response_code, response_definition in responses.items():
             # Construct response param name components
             literal_response_params = {}
+            response_body_array = False
             response_content = response_definition.get('content', {})
             for mimetype, media_type in response_content.items():
               param_properties = {}

--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -257,8 +257,8 @@ class OpenApiEndpointAdapter():
           for response_code, response_definition in responses.items():
             # Construct response param name components
             literal_response_params = {}
-            required_response_params = []
             response_body_array = False
+            required_response_params = []
             response_content = response_definition.get('content', {})
             for mimetype, media_type in response_content.items():
               param_properties = {}
@@ -484,7 +484,14 @@ class OpenApiEndpointAdapter():
       body_spec = component.content()[component_name]
       required_body_params += body_spec.get('required', [])
 
-      param_properties = body_spec.get('properties')
+      param_properties = {}
+      schema_type = body_spec.get('type')
+      if schema_type:
+        if schema_type == 'object':
+          param_properties = body_spec.get('properties', {})
+        elif schema_type == 'array':
+          param_properties = {'tmp': body_spec['items']}
+
       all_of = body_spec.get('allOf')
       any_of = body_spec.get('anyOf')
       one_of = body_spec.get('oneOf')

--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -73,7 +73,7 @@ class OpenApiEndpointAdapter():
           endpoint: EndpointShowResponse = {}
           endpoint['id'] = endpoint_counter
           endpoint['method'] = http_method.upper()
-          endpoint['host'] = parsed_url.netloc
+          endpoint['host'] = 'localhost' if url == '/' else parsed_url.netloc
 
           joined_path = self.__urljoin(parsed_url.path, path_name)
           split_parts = joined_path.split('/')
@@ -107,7 +107,7 @@ class OpenApiEndpointAdapter():
             elif parsed_url.scheme == 'http':
               endpoint['port'] = '80'
             else:
-              endpoint['port'] = ''
+              endpoint['port'] = '443'
 
           alias_counter = 0
           header_param_counter = 0
@@ -533,7 +533,7 @@ class OpenApiEndpointAdapter():
       endpoint[component_name + 's'] = built_params_list
     else:
       endpoint[component_name + 's'].extend(built_params_list)
-      
+
     del endpoint[literal_component_name]
 
   # urllib.parse.urljoin() doesn't work for some of our edge cases

--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -78,14 +78,27 @@ class OpenApiEndpointAdapter():
           joined_path = self.__urljoin(parsed_url.path, path_name)
           split_parts = joined_path.split('/')
           pattern_path = []
+          segment_names = []
           for part in split_parts:
             sanitized_part = part
+            segment_name = part
             if part.startswith('{') and part.endswith('}'):
               sanitized_part = '%' 
+              segment_name = f":{part[1:-1]}"
             pattern_path.append(sanitized_part)
+            segment_names.append(segment_name)
           pattern_path_str = '/'.join(pattern_path)
           endpoint['match_pattern'] = pattern_path_str
           endpoint['path'] = joined_path
+
+          endpoint['path_segment_names'] = []
+          for segment_name in segment_names:
+            if segment_name == "":
+              continue
+            path_component_name: RequestComponentName = {}
+            path_component_name['name'] = segment_name
+            path_component_name['type'] = "Alias" if segment_name.startswith(':') else "Static"
+            endpoint['path_segment_names'].append(path_component_name)
           
           endpoint['port'] = str(parsed_url.port)
           if endpoint['port'] is None or endpoint['port'] == 'None':

--- a/stoobly_agent/app/models/types/endpoint.py
+++ b/stoobly_agent/app/models/types/endpoint.py
@@ -2,6 +2,14 @@ from typing import Literal, TypedDict
 
 OPENAPI_FORMAT = 'openapi'
 
+ENDPOINT_COMPONENT_NAMES = [
+    "header_name",
+    "body_param_name",
+    "query_param_name",
+    "response_header_name",
+    "response_param_name"
+]
+
 class EndpointCreateParams(TypedDict):
   host: str
   method: str
@@ -18,8 +26,8 @@ class HeaderNameCreateParams(TypedDict):
   endpoint_id: int
 	
 class ParamNameCreateParams(TypedDict):
-	name: str
-	project_id: str
-	endpoint_id: int
-	inferred_type: str
-	query: str
+  name: str
+  project_id: str
+  endpoint_id: int
+  inferred_type: str
+  query: str

--- a/stoobly_agent/app/models/types/endpoint.py
+++ b/stoobly_agent/app/models/types/endpoint.py
@@ -3,5 +3,23 @@ from typing import Literal, TypedDict
 OPENAPI_FORMAT = 'openapi'
 
 class EndpointCreateParams(TypedDict):
-  format: Literal[f"{OPENAPI_FORMAT}"]
+  host: str
+  method: str
+  path_segments: str
   path: str
+  port: str
+  project_id: str
+
+class HeaderNameCreateParams(TypedDict):
+  name: str
+  is_required: bool
+  is_deterministic: bool
+  project_id: str
+  endpoint_id: int
+	
+class ParamNameCreateParams(TypedDict):
+	name: str
+	project_id: str
+	endpoint_id: int
+	inferred_type: str
+	query: str

--- a/stoobly_agent/app/models/types/endpoint.py
+++ b/stoobly_agent/app/models/types/endpoint.py
@@ -1,13 +1,13 @@
-from typing import Literal, TypedDict
+from typing import TypedDict
 
 OPENAPI_FORMAT = 'openapi'
 
 ENDPOINT_COMPONENT_NAMES = [
-    "header_name",
-    "body_param_name",
-    "query_param_name",
-    "response_header_name",
-    "response_param_name"
+  "header_name",
+  "body_param_name",
+  "query_param_name",
+  "response_header_name",
+  "response_param_name"
 ]
 
 class EndpointCreateParams(TypedDict):

--- a/stoobly_agent/lib/api/api.py
+++ b/stoobly_agent/lib/api/api.py
@@ -69,3 +69,7 @@ class Api():
     def put(self, url, **kwargs):
       handler = lambda: requests.put(url, **kwargs)
       return self.without_proxy(handler)
+    
+    def delete(self, url, **kwargs):
+      handler = lambda: requests.delete(url, **kwargs)
+      return self.without_proxy(handler)

--- a/stoobly_agent/lib/api/body_param_names_resource.py
+++ b/stoobly_agent/lib/api/body_param_names_resource.py
@@ -10,26 +10,26 @@ from .endpoints_resource import EndpointsResource
 class BodyParamNamesResource(EndpointsResource):
   BODY_PARAM_NAMES_ENDPOINT = 'body_param_names'
 
-  def create(self, **params: ParamNameCreateParams):
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}"
+  def create(self, endpoint_id: int, params: ParamNameCreateParams = {}):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.BODY_PARAM_NAMES_ENDPOINT}"
     return self.post(url, headers=self.default_headers, json=params)
 
-  def index(self, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}"
+  def index(self, endpoint_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.BODY_PARAM_NAMES_ENDPOINT}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
 
-  def show(self, body_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
+  def show(self, endpoint_id: int, body_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
   
-  def destroy(self, body_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
+  def destroy(self, endpoint_id, body_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 

--- a/stoobly_agent/lib/api/body_param_names_resource.py
+++ b/stoobly_agent/lib/api/body_param_names_resource.py
@@ -1,0 +1,36 @@
+import requests
+import urllib
+import pdb
+
+from stoobly_agent.app.models.types import ParamNameCreateParams
+
+from ..logger import Logger
+from .endpoints_resource import EndpointsResource
+
+class BodyParamNamesResource(EndpointsResource):
+  BODY_PARAM_NAMES_ENDPOINT = 'body_param_names'
+
+  def create(self, **params: ParamNameCreateParams):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}"
+    return self.post(url, headers=self.default_headers, json=params)
+
+  def index(self, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+
+  def show(self, body_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+  
+  def destroy(self, body_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.BODY_PARAM_NAMES_ENDPOINT}/{body_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/endpoints_resource.py
+++ b/stoobly_agent/lib/api/endpoints_resource.py
@@ -11,7 +11,7 @@ class EndpointsResource(StooblyApi):
 
   def create(self, **params):
     url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}"
-    return self.post(url, headers=self.default_headers, data=params)
+    return self.post(url, headers=self.default_headers, json=params)
 
   def index(self, **query_params: EndpointsIndexQueryParams) -> requests.Response:
     url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}"
@@ -26,3 +26,10 @@ class EndpointsResource(StooblyApi):
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
+
+  def destroy(self, endpoint_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/header_names_resource.py
+++ b/stoobly_agent/lib/api/header_names_resource.py
@@ -1,0 +1,36 @@
+import requests
+import urllib
+import pdb
+
+from stoobly_agent.app.models.types import HeaderNameCreateParams
+
+from ..logger import Logger
+from .endpoints_resource import EndpointsResource
+
+class HeaderNamesResource(EndpointsResource):
+  HEADER_NAMES_ENDPOINT = 'header_names'
+
+  def create(self, **params: HeaderNameCreateParams):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}"
+    return self.post(url, headers=self.default_headers, json=params)
+
+  def index(self, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+
+  def show(self, header_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+  
+  def destroy(self, header_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/header_names_resource.py
+++ b/stoobly_agent/lib/api/header_names_resource.py
@@ -10,26 +10,26 @@ from .endpoints_resource import EndpointsResource
 class HeaderNamesResource(EndpointsResource):
   HEADER_NAMES_ENDPOINT = 'header_names'
 
-  def create(self, **params: HeaderNameCreateParams):
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}"
+  def create(self, endpoint_id: int, params: HeaderNameCreateParams = {}):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.HEADER_NAMES_ENDPOINT}"
     return self.post(url, headers=self.default_headers, json=params)
 
-  def index(self, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}"
+  def index(self, endpoint_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.HEADER_NAMES_ENDPOINT}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
 
-  def show(self, header_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
+  def show(self, endpoint_id: int, header_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
   
-  def destroy(self, header_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
+  def destroy(self, endpoint_id: int, header_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.HEADER_NAMES_ENDPOINT}/{header_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 

--- a/stoobly_agent/lib/api/interfaces/endpoints.py
+++ b/stoobly_agent/lib/api/interfaces/endpoints.py
@@ -43,8 +43,10 @@ class EndpointShowResponse(TypedDict):
   path_segment_names: List[RequestComponentName]
   query_param_names: List[RequestComponentName]
   response_param_names: List[ResponseParamName]
+  response_header_names: List[RequestComponentName]
   literal_query_params: Optional[dict]
   literal_body_params: Optional[dict]
+  literal_response_params: Optional[dict]
 
 ARRAY_TYPE = 'Array'
 

--- a/stoobly_agent/lib/api/query_param_names_resource.py
+++ b/stoobly_agent/lib/api/query_param_names_resource.py
@@ -1,0 +1,36 @@
+import requests
+import urllib
+import pdb
+
+from stoobly_agent.app.models.types import ParamNameCreateParams
+
+from ..logger import Logger
+from .endpoints_resource import EndpointsResource
+
+class QueryParamNamesResource(EndpointsResource):
+  QUERY_PARAM_NAMES_ENDPOINT = 'query_param_names'
+
+  def create(self, **params: ParamNameCreateParams):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
+    return self.post(url, headers=self.default_headers, json=params)
+
+  def index(self, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+
+  def show(self, query_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+  
+  def destroy(self, query_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/query_param_names_resource.py
+++ b/stoobly_agent/lib/api/query_param_names_resource.py
@@ -10,26 +10,26 @@ from .endpoints_resource import EndpointsResource
 class QueryParamNamesResource(EndpointsResource):
   QUERY_PARAM_NAMES_ENDPOINT = 'query_param_names'
 
-  def create(self, **params: ParamNameCreateParams):
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
+  def create(self, endpoint_id: int, params: ParamNameCreateParams = {}):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
     return self.post(url, headers=self.default_headers, json=params)
 
-  def index(self, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
+  def index(self, endpoint_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.QUERY_PARAM_NAMES_ENDPOINT}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
 
-  def show(self, query_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
+  def show(self, endpoint_id: int, query_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
   
-  def destroy(self, query_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
+  def destroy(self, endpoint_id: int, query_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.QUERY_PARAM_NAMES_ENDPOINT}/{query_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 

--- a/stoobly_agent/lib/api/response_header_names_resource.py
+++ b/stoobly_agent/lib/api/response_header_names_resource.py
@@ -1,0 +1,36 @@
+import requests
+import urllib
+import pdb
+
+from stoobly_agent.app.models.types import HeaderNameCreateParams
+
+from ..logger import Logger
+from .endpoints_resource import EndpointsResource
+
+class ResponseHeaderNamesResource(EndpointsResource):
+  RESPONSE_HEADER_NAME_ENDPOINT = 'response_header_names'
+
+  def create(self, **params: HeaderNameCreateParams):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
+    return self.post(url, headers=self.default_headers, json=params)
+
+  def index(self, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+
+  def show(self, response_header_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+  
+  def destroy(self, response_header_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/response_header_names_resource.py
+++ b/stoobly_agent/lib/api/response_header_names_resource.py
@@ -10,26 +10,26 @@ from .endpoints_resource import EndpointsResource
 class ResponseHeaderNamesResource(EndpointsResource):
   RESPONSE_HEADER_NAME_ENDPOINT = 'response_header_names'
 
-  def create(self, **params: HeaderNameCreateParams):
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
+  def create(self, endpoint_id: int, params: HeaderNameCreateParams = {}):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
     return self.post(url, headers=self.default_headers, json=params)
 
-  def index(self, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
+  def index(self, endpoint_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_HEADER_NAME_ENDPOINT}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
 
-  def show(self, response_header_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
+  def show(self, endpoint_id: int, response_header_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
   
-  def destroy(self, response_header_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
+  def destroy(self, endpoint_id: int, response_header_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_HEADER_NAME_ENDPOINT}/{response_header_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 

--- a/stoobly_agent/lib/api/response_param_names_resource.py
+++ b/stoobly_agent/lib/api/response_param_names_resource.py
@@ -1,0 +1,36 @@
+import requests
+import urllib
+import pdb
+
+from stoobly_agent.app.models.types import ParamNameCreateParams
+
+from ..logger import Logger
+from .endpoints_resource import EndpointsResource
+
+class ResponseParamNamesResource(EndpointsResource):
+  RESPONSE_PARAM_NAMES_ENDPOINT = 'response_param_names'
+
+  def create(self, **params: ParamNameCreateParams):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
+    return self.post(url, headers=self.default_headers, json=params)
+
+  def index(self, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+
+  def show(self, response_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.get(url, headers=self.default_headers, params=query_params)
+  
+  def destroy(self, response_param_name_id: int, **query_params) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
+
+    Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
+
+    return self.delete(url, headers=self.default_headers, params=query_params)

--- a/stoobly_agent/lib/api/response_param_names_resource.py
+++ b/stoobly_agent/lib/api/response_param_names_resource.py
@@ -10,26 +10,26 @@ from .endpoints_resource import EndpointsResource
 class ResponseParamNamesResource(EndpointsResource):
   RESPONSE_PARAM_NAMES_ENDPOINT = 'response_param_names'
 
-  def create(self, **params: ParamNameCreateParams):
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
+  def create(self, endpoint_id: int, params: ParamNameCreateParams = {}):
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
     return self.post(url, headers=self.default_headers, json=params)
 
-  def index(self, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
+  def index(self, endpoint_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
 
-  def show(self, response_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
+  def show(self, endpoint_id: int, response_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 
     return self.get(url, headers=self.default_headers, params=query_params)
   
-  def destroy(self, response_param_name_id: int, **query_params) -> requests.Response:
-    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{query_params['endpoint_id']}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
+  def destroy(self, endpoint_id: int, response_param_name_id: int, query_params = {}) -> requests.Response:
+    url = f"{self.service_url}/{self.ENDPOINTS_ENDPOINT}/{endpoint_id}/{self.RESPONSE_PARAM_NAMES_ENDPOINT}/{response_param_name_id}"
 
     Logger.instance().debug(f"{self.LOG_ID}.request_response:{url}?{urllib.parse.urlencode(query_params)}")
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
@@ -44,6 +44,40 @@ class TestOpenApiEndpointAdapterAdditionalProps():
           "body_param_name_id": None,
           "id": 1
         }
+      ],
+      'path_segment_names': [
+        {
+          'name': 'v1',
+          'type': 'Static'
+        },
+        {
+          'name': 'pets',
+          'type': 'Static'
+        }
+      ],
+      'response_param_names': [
+        {
+          'endpoint_id': 1,
+          'id': 1,
+          'inferred_type': 'Integer',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'code',
+          'query': 'code',
+          'response_param_name_id': None,
+          'values': [0]
+        },
+        {
+          'endpoint_id': 1,
+          'id': 2,
+          'inferred_type': 'String',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'message',
+          'query': 'message',
+          'response_param_name_id': None,
+          'values': ['']
+        }
       ]
     }
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
@@ -48,11 +48,11 @@ class TestOpenApiEndpointAdapterAdditionalProps():
       'path_segment_names': [
         {
           'name': 'v1',
-          'type': 'Static'
+          'type': 'static'
         },
         {
           'name': 'pets',
-          'type': 'Static'
+          'type': 'static'
         }
       ],
       'response_param_names': [

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
@@ -58,29 +58,69 @@ class TestOpenApiEndpointAdapterMissingInfo():
           'name': 'x-next',
         },
       ],
-     'response_param_names': [
+      "response_param_names": [
         {
-          'endpoint_id': 1,
-          'id': 1,
-          'inferred_type': 'Integer',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'code',
-          'query': 'code',
-          'response_param_name_id': None,
-          'values': [0],
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "id",
+          "query": "id",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
         },
         {
-          'endpoint_id': 1,
-          'id': 2,
-          'inferred_type': 'String',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'message',
-          'query': 'message',
-          'response_param_name_id': None,
-          'values': [''],
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "name",
+          "query": "name",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
         },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": False,
+          "is_deterministic": True,
+          "name": "tag",
+          "query": "tag",
+          "response_param_name_id": None,
+          "id": 3
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "code",
+          "query": "code",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "message",
+          "query": "message",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
+        }
       ],
     }
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
@@ -29,10 +29,10 @@ class TestOpenApiEndpointAdapterMissingInfo():
     return {
       "id": 1,
       "method": "GET",
-      "host": "localhost",
+      "host": "-",
       "match_pattern": "/pets",
       "path": "/pets",
-      "port": "443",
+      "port": "0",
       "query_param_names": [
         {
           "endpoint_id": 1,
@@ -48,7 +48,7 @@ class TestOpenApiEndpointAdapterMissingInfo():
      'path_segment_names': [
         {
           'name': 'pets',
-          'type': 'Static',
+          'type': 'static',
         },
       ],
      'response_header_names': [

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
@@ -29,10 +29,10 @@ class TestOpenApiEndpointAdapterMissingInfo():
     return {
       "id": 1,
       "method": "GET",
-      "host": "",
+      "host": "localhost",
       "match_pattern": "/pets",
       "path": "/pets",
-      "port": "",
+      "port": "443",
       "query_param_names": [
         {
           "endpoint_id": 1,
@@ -44,7 +44,44 @@ class TestOpenApiEndpointAdapterMissingInfo():
           "query_param_name_id": None,
           "id": 1
         }
-      ]
+      ],
+     'path_segment_names': [
+        {
+          'name': 'pets',
+          'type': 'Static',
+        },
+      ],
+     'response_header_names': [
+        {
+          'is_deterministic': True,
+          'is_required': False,
+          'name': 'x-next',
+        },
+      ],
+     'response_param_names': [
+        {
+          'endpoint_id': 1,
+          'id': 1,
+          'inferred_type': 'Integer',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'code',
+          'query': 'code',
+          'response_param_name_id': None,
+          'values': [0],
+        },
+        {
+          'endpoint_id': 1,
+          'id': 2,
+          'inferred_type': 'String',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'message',
+          'query': 'message',
+          'response_param_name_id': None,
+          'values': [''],
+        },
+      ],
     }
 
   def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_file_path, expected_get_pets_endpoint):

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
@@ -62,29 +62,69 @@ class TestOpenApiEndpointAdapterMissingOauthScopes():
           'name': 'x-next',
         },
       ],
-      'response_param_names': [
+        "response_param_names": [
         {
-          'endpoint_id': 1,
-          'id': 1,
-          'inferred_type': 'Integer',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'code',
-          'query': 'code',
-          'response_param_name_id': None,
-          'values': [0],
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "id",
+          "query": "id",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
         },
         {
-          'endpoint_id': 1,
-          'id': 2,
-          'inferred_type': 'String',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'message',
-          'query': 'message',
-          'response_param_name_id': None,
-          'values': [''],
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "name",
+          "query": "name",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
         },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": False,
+          "is_deterministic": True,
+          "name": "tag",
+          "query": "tag",
+          "response_param_name_id": None,
+          "id": 3
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "code",
+          "query": "code",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "message",
+          "query": "message",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
+        }
       ],
     }
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
@@ -44,7 +44,48 @@ class TestOpenApiEndpointAdapterMissingOauthScopes():
           "query_param_name_id": None,
           "id": 1
         }
-      ]
+      ],
+      'path_segment_names': [
+        {
+          'name': 'v1',
+          'type': 'Static',
+        },
+        {
+          'name': 'pets',
+          'type': 'Static',
+        },
+      ],
+      'response_header_names': [
+        {
+          'is_deterministic': True,
+          'is_required': False,
+          'name': 'x-next',
+        },
+      ],
+      'response_param_names': [
+        {
+          'endpoint_id': 1,
+          'id': 1,
+          'inferred_type': 'Integer',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'code',
+          'query': 'code',
+          'response_param_name_id': None,
+          'values': [0],
+        },
+        {
+          'endpoint_id': 1,
+          'id': 2,
+          'inferred_type': 'String',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'message',
+          'query': 'message',
+          'response_param_name_id': None,
+          'values': [''],
+        },
+      ],
     }
 
   def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_file_path, expected_get_pets_endpoint):

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
@@ -48,11 +48,11 @@ class TestOpenApiEndpointAdapterMissingOauthScopes():
       'path_segment_names': [
         {
           'name': 'v1',
-          'type': 'Static',
+          'type': 'static',
         },
         {
           'name': 'pets',
-          'type': 'Static',
+          'type': 'static',
         },
       ],
       'response_header_names': [

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
@@ -29,10 +29,10 @@ class TestOpenApiEndpointAdapterMissingServers():
     return {
       "id": 1,
       "method": "GET",
-      "host": "localhost",
+      "host": "-",
       "match_pattern": "/pets",
       "path": "/pets",
-      "port": "443",
+      "port": "0",
       "query_param_names": [
         {
           "endpoint_id": 1,
@@ -48,7 +48,7 @@ class TestOpenApiEndpointAdapterMissingServers():
       'path_segment_names': [
         {
           'name': 'pets',
-          'type': 'Static',
+          'type': 'static',
         },
       ],
       'response_header_names': [

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
@@ -29,10 +29,10 @@ class TestOpenApiEndpointAdapterMissingServers():
     return {
       "id": 1,
       "method": "GET",
-      "host": "",
+      "host": "localhost",
       "match_pattern": "/pets",
       "path": "/pets",
-      "port": "",
+      "port": "443",
       "query_param_names": [
         {
           "endpoint_id": 1,
@@ -44,7 +44,44 @@ class TestOpenApiEndpointAdapterMissingServers():
           "query_param_name_id": None,
           "id": 1
         }
-      ]
+      ],
+      'path_segment_names': [
+        {
+          'name': 'pets',
+          'type': 'Static',
+        },
+      ],
+      'response_header_names': [
+        {
+          'is_deterministic': True,
+          'is_required': False,
+          'name': 'x-next',
+        },
+      ],
+      'response_param_names': [
+        {
+          'endpoint_id': 1,
+          'id': 1,
+          'inferred_type': 'Integer',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'code',
+          'query': 'code',
+          'response_param_name_id': None,
+          'values': [0],
+        },
+        {
+          'endpoint_id': 1,
+          'id': 2,
+          'inferred_type': 'String',
+          'is_deterministic': True,
+          'is_required': True,
+          'name': 'message',
+          'query': 'message',
+          'response_param_name_id': None,
+          'values': [''],
+        },
+      ],
     }
 
   def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_file_path, expected_get_pets_endpoint):

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
@@ -58,29 +58,69 @@ class TestOpenApiEndpointAdapterMissingServers():
           'name': 'x-next',
         },
       ],
-      'response_param_names': [
+      "response_param_names": [
         {
-          'endpoint_id': 1,
-          'id': 1,
-          'inferred_type': 'Integer',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'code',
-          'query': 'code',
-          'response_param_name_id': None,
-          'values': [0],
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "id",
+          "query": "id",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
         },
         {
-          'endpoint_id': 1,
-          'id': 2,
-          'inferred_type': 'String',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'message',
-          'query': 'message',
-          'response_param_name_id': None,
-          'values': [''],
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "name",
+          "query": "name",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
         },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": False,
+          "is_deterministic": True,
+          "name": "tag",
+          "query": "tag",
+          "response_param_name_id": None,
+          "id": 3
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "Integer",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "code",
+          "query": "code",
+          "response_param_name_id": None,
+          "id": 1,
+          "values": [
+            0
+          ]
+        },
+        {
+          "endpoint_id": 1,
+          "inferred_type": "String",
+          "is_required": True,
+          "is_deterministic": True,
+          "name": "message",
+          "query": "message",
+          "response_param_name_id": None,
+          "id": 2,
+          "values": [
+            ""
+          ]
+        }
       ],
     }
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
@@ -88,6 +88,81 @@ class TestOpenApiEndpointAdapter():
             'query': 'limit',
             'query_param_name_id': None,
           }
+        ],
+        'path_segment_names': [
+          {
+            'name': 'v2',
+            'type': 'Static'
+          },
+          {
+            'name': 'pets',
+            'type': 'Static'
+          }
+        ],
+        'response_param_names': [
+          {
+            'endpoint_id': 1,
+            'id': 1,
+            'inferred_type': 'Hash',
+            'is_required': False,
+            'name': 'Element',
+            'query': '[*]',
+            'response_param_name_id': None
+          },
+          {
+            'endpoint_id': 1,
+            'id': 2,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'name',
+            'query': '[*].name',
+            'response_param_name_id': 1,
+            'values': ['']
+          },
+          {
+            'endpoint_id': 1,
+            'id': 3,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'tag',
+            'query': '[*].tag',
+            'response_param_name_id': 1
+          },
+          {
+            'endpoint_id': 1,
+            'id': 4,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'id',
+            'query': '[*].id',
+            'response_param_name_id': 1,
+            'values': [0]
+          },
+          {
+            'endpoint_id': 1,
+            'id': 1,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'code',
+            'query': 'code',
+            'response_param_name_id': None,
+            'values': [0]
+          },
+          {
+            'endpoint_id': 1,
+            'id': 2,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'message',
+            'query': 'message',
+            'response_param_name_id': None,
+            'values': ['']
+          }
         ]
       }
 
@@ -123,6 +198,72 @@ class TestOpenApiEndpointAdapter():
             'query': 'tag',
           },
         ],
+        'path_segment_names': [
+          {
+              'name': 'v2',
+              'type': 'Static',
+          },
+          {
+              'name': 'pets',
+              'type': 'Static',
+          },
+        ],
+        'response_param_names': [
+          {
+              'endpoint_id': 2,
+              'id': 1,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'name',
+              'query': 'name',
+              'response_param_name_id': None,
+              'values': [''],
+          },
+          {
+              'endpoint_id': 2,
+              'id': 2,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': False,
+              'name': 'tag',
+              'query': 'tag',
+              'response_param_name_id': None,
+          },
+          {
+              'endpoint_id': 2,
+              'id': 3,
+              'inferred_type': 'Integer',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'id',
+              'query': 'id',
+              'response_param_name_id': None,
+              'values': [0],
+          },
+          {
+              'endpoint_id': 2,
+              'id': 1,
+              'inferred_type': 'Integer',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'code',
+              'query': 'code',
+              'response_param_name_id': None,
+              'values': [0],
+          },
+          {
+              'endpoint_id': 2,
+              'id': 2,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'message',
+              'query': 'message',
+              'response_param_name_id': None,
+              'values': [''],
+          },
+        ],
       }
 
     @pytest.fixture(scope='class')
@@ -135,6 +276,76 @@ class TestOpenApiEndpointAdapter():
         'path': '/v2/pets/{id}',
         'match_pattern': '/v2/pets/%',
         'aliases': [{'id': 1, 'name': '{id}'}],
+        'path_segment_names': [
+            {
+                'name': 'v2',
+                'type': 'Static',
+            },
+            {
+                'name': 'pets',
+                'type': 'Static',
+            },
+            {
+                'name': ':id',
+                'type': 'Alias',
+            },
+        ],
+        'response_param_names': [
+            {
+                'endpoint_id': 3,
+                'id': 1,
+                'inferred_type': 'String',
+                'is_deterministic': True,
+                'is_required': True,
+                'name': 'name',
+                'query': 'name',
+                'response_param_name_id': None,
+                'values': [''],
+            },
+            {
+                'endpoint_id': 3,
+                'id': 2,
+                'inferred_type': 'String',
+                'is_deterministic': True,
+                'is_required': False,
+                'name': 'tag',
+                'query': 'tag',
+                'response_param_name_id': None,
+            },
+            {
+                'endpoint_id': 3,
+                'id': 3,
+                'inferred_type': 'Integer',
+                'is_deterministic': True,
+                'is_required': True,
+                'name': 'id',
+                'query': 'id',
+                'response_param_name_id': None,
+                'values': [0],
+            },
+            {
+                'endpoint_id': 3,
+                'id': 1,
+                'inferred_type': 'Integer',
+                'is_deterministic': True,
+                'is_required': True,
+                'name': 'code',
+                'query': 'code',
+                'response_param_name_id': None,
+                'values': [0],
+            },
+            {
+                'endpoint_id': 3,
+                'id': 2,
+                'inferred_type': 'String',
+                'is_deterministic': True,
+                'is_required': True,
+                'name': 'message',
+                'query': 'message',
+                'response_param_name_id': None,
+                'values': [''],
+            },
+        ],
       }
 
     @pytest.fixture(scope='class')
@@ -147,6 +358,44 @@ class TestOpenApiEndpointAdapter():
         'match_pattern': '/v2/pets/%',
         'port': '443',
         'aliases': [{'id': 1, 'name': '{id}'}],
+        'path_segment_names': [
+          {
+            'name': 'v2',
+            'type': 'Static',
+          },
+          {
+            'name': 'pets',
+            'type': 'Static',
+          },
+          {
+            'name': ':id',
+            'type': 'Alias',
+          },
+        ],
+        'response_param_names': [
+          {
+            'endpoint_id': 4,
+            'id': 1,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'code',
+            'query': 'code',
+            'response_param_name_id': None,
+            'values': [0],
+          },
+          {
+            'endpoint_id': 4,
+            'id': 2,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'message',
+            'query': 'message',
+            'response_param_name_id': None,
+            'values': [''],
+          },
+        ],
       }
 
     def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_expanded_file_path, expected_v2_get_pets_endpoint, expected_v2_post_pets_endpoint, expected_v2_get_pets_id_endpoint, expected_v2_delete_pets_id_endpoint):
@@ -179,6 +428,34 @@ class TestOpenApiEndpointAdapter():
         'port': '443',
         'path': '/ds-api/',
         'match_pattern': '/ds-api/',
+        'path_segment_names': [
+          {
+            'name': 'ds-api',
+            'type': 'Static',
+          },
+        ],
+        'response_param_names': [
+          {
+            'endpoint_id': 1,
+            'id': 1,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'total',
+            'query': 'total',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 2,
+            'inferred_type': 'Array',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'apis',
+            'query': 'apis',
+            'response_param_name_id': None,
+          },
+        ],
       }
 
     @pytest.fixture(scope='class')
@@ -186,6 +463,8 @@ class TestOpenApiEndpointAdapter():
       http_endpoint_version = copy.deepcopy(expected_get_root_https)
       http_endpoint_version['id'] = 4
       http_endpoint_version['port'] = '80'
+      for response_param_name in http_endpoint_version['response_param_names']:
+        response_param_name['endpoint_id'] = 4
       return http_endpoint_version
 
     @pytest.fixture(scope='class')
@@ -198,6 +477,24 @@ class TestOpenApiEndpointAdapter():
         'match_pattern': '/ds-api/%/%/fields',
         'path': '/ds-api/{dataset}/{version}/fields',
         'aliases': [{'id': 1, 'name': '{dataset}'}, {'id': 2, 'name': '{version}'}],
+        'path_segment_names': [
+          {
+            'name': 'ds-api',
+            'type': 'Static',
+          },
+          {
+            'name': ':dataset',
+            'type': 'Alias',
+          },
+          {
+            'name': ':version',
+            'type': 'Alias',
+          },
+          {
+            'name': 'fields',
+            'type': 'Static',
+          },
+        ],
       }
 
     @pytest.fixture(scope='class')
@@ -249,6 +546,24 @@ class TestOpenApiEndpointAdapter():
             'name': 'rows',
             'query': 'rows',
           }
+        ],
+        'path_segment_names': [
+          {
+            'name': 'ds-api',
+            'type': 'Static',
+          },
+          {
+            'name': ':dataset',
+            'type': 'Alias',
+          },
+          {
+            'name': ':version',
+            'type': 'Alias',
+          },
+          {
+            'name': 'records',
+            'type': 'Static',
+          },
         ],
       }
 
@@ -383,6 +698,40 @@ class TestOpenApiEndpointAdapter():
             'values': [0],
           },
         ],
+        'path_segment_names': [
+          {
+            'name': 'v1',
+            'type': 'Static',
+          },
+          {
+            'name': 'pets',
+            'type': 'Static',
+          },
+        ],
+        'response_param_names': [
+          {
+            'endpoint_id': 1,
+            'id': 1,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'code',
+            'query': 'code',
+            'response_param_name_id': None,
+            'values': [0],
+          },
+          {
+            'endpoint_id': 1,
+            'id': 2,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': True,
+            'name': 'message',
+            'query': 'message',
+            'response_param_name_id': None,
+            'values': [''],
+          },
+        ],
       }
 
     @pytest.fixture(scope='class')
@@ -500,6 +849,41 @@ class TestOpenApiEndpointAdapter():
             'query': 'id',
             'values': [0]}
           ],
+          'path_segment_names': [
+            {
+              'name': 'v2',
+              'type': 'Static',
+            },
+            {
+              'name': 'pets',
+              'type': 'Static',
+            },
+          ],
+          'response_param_names': [
+            {
+              'endpoint_id': 2,
+              'id': 1,
+              'inferred_type': 'Integer',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'code',
+              'query': 'code',
+              'response_param_name_id': None,
+              'values': [0],
+            },
+            {
+              'endpoint_id': 2,
+              'id': 2,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'message',
+              'query': 'message',
+              'response_param_name_id': None,
+              'values': [''],
+            },
+          ],
+
         }
 
     def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_references_file_path, expected_get_v1_pets_ref, expected_get_v2_pets_ref):
@@ -521,12 +905,12 @@ class TestOpenApiEndpointAdapter():
     @pytest.fixture(scope='class')
     def expected_put_v3_pets_ref(self) -> Dict:
       return {
-        'host': '',
+        'host': 'localhost',
         'id': 1,
         'match_pattern': '/v3/pet',
         'method': 'PUT',
         'path': '/v3/pet',
-        'port': '',
+        'port': '443',
         'body_param_names': [
           {
             'body_param_name_id': None,
@@ -649,17 +1033,149 @@ class TestOpenApiEndpointAdapter():
             'query': 'status'
           },
         ],
+        'path_segment_names': [
+          {
+              'name': 'v3',
+              'type': 'Static',
+          },
+          {
+              'name': 'pet',
+              'type': 'Static',
+          },
+        ],
+        'response_param_names': [
+          {
+              'endpoint_id': 1,
+              'id': 1,
+              'inferred_type': 'Integer',
+              'is_deterministic': True,
+              'is_required': False,
+              'name': 'id',
+              'query': 'id',
+              'response_param_name_id': None,
+          },
+          {
+              'endpoint_id': 1,
+              'id': 2,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'name',
+              'query': 'name',
+              'response_param_name_id': None,
+              'values': [''],
+          },
+          {
+              'endpoint_id': 1,
+              'id': 3,
+              'inferred_type': 'Hash',
+              'is_deterministic': True,
+              'is_required': False,
+              'name': 'category',
+              'query': 'category',
+              'response_param_name_id': None,
+          },
+          {
+              'endpoint_id': 1,
+              'id': 4,
+              'inferred_type': 'Integer',
+              'is_deterministic': True,
+              'is_required': False,
+              'name': 'id',
+              'query': 'category.id',
+              'response_param_name_id': 3,
+          },
+          {
+              'endpoint_id': 1,
+              'id': 5,
+              'inferred_type': 'String',
+              'is_deterministic': True,
+              'is_required': False,
+              'name': 'name',
+              'query': 'category.name',
+              'response_param_name_id': 3,
+          },
+          {
+              'endpoint_id': 1,
+              'id': 6,
+              'inferred_type': 'Array',
+              'is_deterministic': True,
+              'is_required': True,
+              'name': 'photoUrls',
+              'query': 'photoUrls',
+              'response_param_name_id': None,
+              'values': [[]],
+          },
+          {
+            'endpoint_id': 1,
+            'id': 7,
+            'inferred_type': 'String',
+            'is_required': False,
+            'name': 'PhotourlsElement',
+            'query': 'photoUrls[*]',
+            'response_param_name_id': 6,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 8,
+            'inferred_type': 'Array',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'tags',
+            'query': 'tags',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 9,
+            'inferred_type': 'Hash',
+            'is_required': False,
+            'name': 'TagsElement',
+            'query': 'tags[*]',
+            'response_param_name_id': 8,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 10,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'id',
+            'query': 'tags[*].id',
+            'response_param_name_id': 9,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 11,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'name',
+            'query': 'tags[*].name',
+            'response_param_name_id': 9,
+          },
+          {
+            'endpoint_id': 1,
+            'id': 12,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'status',
+            'query': 'status',
+            'response_param_name_id': None,
+          },
+        ],
       }
 
     @pytest.fixture(scope='class')
     def expected_post_v3_user_createwithlist(self) -> Dict:
       return {
-        'host': '',
+        'host': 'localhost',
         'id': 14,
         'match_pattern': '/v3/user/createWithList',
         'method': 'POST',
         'path': '/v3/user/createWithList',
-        'port': '',
+        'port': '443',
         'body_param_names': [
           {
             'body_param_name_id': None,
@@ -751,6 +1267,103 @@ class TestOpenApiEndpointAdapter():
             'query': '[*].userStatus'
           }
         ],
+        'path_segment_names': [
+          {
+            'name': 'v3',
+            'type': 'Static',
+          },
+          {
+            'name': 'user',
+            'type': 'Static',
+          },
+          {
+            'name': 'createWithList',
+            'type': 'Static',
+          },
+        ],
+        'response_param_names': [
+          {
+            'endpoint_id': 14,
+            'id': 1,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'id',
+            'query': 'id',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 2,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'username',
+            'query': 'username',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 3,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'firstName',
+            'query': 'firstName',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 4,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'lastName',
+            'query': 'lastName',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 5,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'email',
+            'query': 'email',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 6,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'password',
+            'query': 'password',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 7,
+            'inferred_type': 'String',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'phone',
+            'query': 'phone',
+            'response_param_name_id': None,
+          },
+          {
+            'endpoint_id': 14,
+            'id': 8,
+            'inferred_type': 'Integer',
+            'is_deterministic': True,
+            'is_required': False,
+            'name': 'userStatus',
+            'query': 'userStatus',
+            'response_param_name_id': None,
+          },
+        ],
+
       }
 
     def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_swagger_io_file_path, expected_put_v3_pets_ref, expected_post_v3_user_createwithlist):

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
@@ -92,11 +92,11 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'v2',
-            'type': 'Static'
+            'type': 'static'
           },
           {
             'name': 'pets',
-            'type': 'Static'
+            'type': 'static'
           }
         ],
         'response_param_names': [
@@ -201,11 +201,11 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
               'name': 'v2',
-              'type': 'Static',
+              'type': 'static',
           },
           {
               'name': 'pets',
-              'type': 'Static',
+              'type': 'static',
           },
         ],
         'response_param_names': [
@@ -279,15 +279,15 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
             {
                 'name': 'v2',
-                'type': 'Static',
+                'type': 'static',
             },
             {
                 'name': 'pets',
-                'type': 'Static',
+                'type': 'static',
             },
             {
                 'name': ':id',
-                'type': 'Alias',
+                'type': 'alias',
             },
         ],
         'response_param_names': [
@@ -361,15 +361,15 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'v2',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': 'pets',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': ':id',
-            'type': 'Alias',
+            'type': 'alias',
           },
         ],
         'response_param_names': [
@@ -431,7 +431,7 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'ds-api',
-            'type': 'Static',
+            'type': 'static',
           },
         ],
         'response_param_names': [
@@ -480,19 +480,19 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'ds-api',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': ':dataset',
-            'type': 'Alias',
+            'type': 'alias',
           },
           {
             'name': ':version',
-            'type': 'Alias',
+            'type': 'alias',
           },
           {
             'name': 'fields',
-            'type': 'Static',
+            'type': 'static',
           },
         ],
       }
@@ -550,19 +550,19 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'ds-api',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': ':dataset',
-            'type': 'Alias',
+            'type': 'alias',
           },
           {
             'name': ':version',
-            'type': 'Alias',
+            'type': 'alias',
           },
           {
             'name': 'records',
-            'type': 'Static',
+            'type': 'static',
           },
         ],
       }
@@ -701,11 +701,11 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'v1',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': 'pets',
-            'type': 'Static',
+            'type': 'static',
           },
         ],
         'response_param_names': [
@@ -852,11 +852,11 @@ class TestOpenApiEndpointAdapter():
           'path_segment_names': [
             {
               'name': 'v2',
-              'type': 'Static',
+              'type': 'static',
             },
             {
               'name': 'pets',
-              'type': 'Static',
+              'type': 'static',
             },
           ],
           'response_param_names': [
@@ -905,12 +905,12 @@ class TestOpenApiEndpointAdapter():
     @pytest.fixture(scope='class')
     def expected_put_v3_pets_ref(self) -> Dict:
       return {
-        'host': 'localhost',
+        'host': '-',
         'id': 1,
         'match_pattern': '/v3/pet',
         'method': 'PUT',
         'path': '/v3/pet',
-        'port': '443',
+        'port': '0',
         'body_param_names': [
           {
             'body_param_name_id': None,
@@ -1036,11 +1036,11 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
               'name': 'v3',
-              'type': 'Static',
+              'type': 'static',
           },
           {
               'name': 'pet',
-              'type': 'Static',
+              'type': 'static',
           },
         ],
         'response_param_names': [
@@ -1170,12 +1170,12 @@ class TestOpenApiEndpointAdapter():
     @pytest.fixture(scope='class')
     def expected_post_v3_user_createwithlist(self) -> Dict:
       return {
-        'host': 'localhost',
+        'host': '-',
         'id': 14,
         'match_pattern': '/v3/user/createWithList',
         'method': 'POST',
         'path': '/v3/user/createWithList',
-        'port': '443',
+        'port': '0',
         'body_param_names': [
           {
             'body_param_name_id': None,
@@ -1270,15 +1270,15 @@ class TestOpenApiEndpointAdapter():
         'path_segment_names': [
           {
             'name': 'v3',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': 'user',
-            'type': 'Static',
+            'type': 'static',
           },
           {
             'name': 'createWithList',
-            'type': 'Static',
+            'type': 'static',
           },
         ],
         'response_param_names': [


### PR DESCRIPTION
## Changes Made:
Extended OAS adapter to handle parsing of static and aliased path segments + response bodies in OpenAPI description files and generation of response_header_name and response_param_name resources. Additionally, added new resource classes for component names (header_names, body_param_names, query_param_names, response_param_names, response_header_names), a new endpoint importer service (`endpoints_import_service.py`), and the `endpoint import` cli command in `endpoint_cli.py`.

## Expected Benefits:
Allows users to more easily create and maintain mocks by importing OAS directly into Stoobly using the `endpoint import` cli command #212 

## Additional Notes:
The `endpoint import` command currently does not work with OpenAPI files that include HEAD, PATCH and TRACE operations since those do not seem to be supported/allowed values for the `method` parameter in the request body for the `POST /endpoints` api route.