### PR TITLE
Fix bug where required query params were not being marked

### DIFF
--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -155,7 +155,10 @@ class OpenApiEndpointAdapter():
                   param_value = self.__open_api_to_default_python_type(open_api_type)
 
               literal_query_param = {
-                parameter['name']: {'value': param_value}
+                parameter['name']: {
+                  'value': param_value,
+                  'required': parameter.get('required', False),
+                }
               }
 
               if not endpoint.get('literal_query_params'):


### PR DESCRIPTION
## Changes Made
Added a `required` field to the `literal_query_param` object so that the `SchemaBuilder` can correctly parse the `required` property value for a query parameter when calling the `__convert_literal_component_param` helper function.

## Expected Benefits
Should fix the bug where the required tag is not marked correctly for query_params (#215)

## New output w/ changes

**Given**:
```
{
  "openapi": "3.0.1",
  "info": {
    "version": "v1"
  },
  "paths": {
    "/v1/transactions": {
      "get": {
        "parameters": [
          {
            "name": "userId",
            "in": "query",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          },
          {
            "name": "locationId",
            "in": "query",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          },
          {
            "name": "status",
            "in": "query",
            "schema": {
              "type": "string",
              "nullable": true
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Success"
          }
        }
      }
    }
}
```
**Expect**:
`userId` and `locationId` should be marked as required

**Result**:
<img width="1226" alt="Screen Shot 2024-04-08 at 4 11 30 PM" src="https://github.com/Stoobly/stoobly-agent/assets/58492699/971ae214-68d5-4661-a34b-72de243eec73">

## Additional Notes:
The `required` field is optional for query parameters and its default value is `false`. Query parameters should only be marked as required if the `required` property is explicitly set to `true` 

Context: [https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#parameter-objec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#parameter-object)
