### PR TITLE
216 sending duplicate response param name create requests

### DIFF
--- a/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
+++ b/stoobly_agent/app/cli/helpers/openapi_endpoint_adapter.py
@@ -603,6 +603,10 @@ class OpenApiEndpointAdapter():
 
   def __parse_responses(self, endpoint: EndpointShowResponse, responses: Spec, components: Spec):
     for response_code, response_definition in responses.items():
+      # Only support status code 200 for now
+      if response_code != '200':
+        continue
+
       # Construct response param name components
       literal_response_params = {}
       response_body_array = False

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_additional_props_test.py
@@ -55,30 +55,6 @@ class TestOpenApiEndpointAdapterAdditionalProps():
           'type': 'static'
         }
       ],
-      'response_param_names': [
-        {
-          'endpoint_id': 1,
-          'id': 1,
-          'inferred_type': 'Integer',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'code',
-          'query': 'code',
-          'response_param_name_id': None,
-          'values': [0]
-        },
-        {
-          'endpoint_id': 1,
-          'id': 2,
-          'inferred_type': 'String',
-          'is_deterministic': True,
-          'is_required': True,
-          'name': 'message',
-          'query': 'message',
-          'response_param_name_id': None,
-          'values': ['']
-        }
-      ]
     }
 
 

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_info_test.py
@@ -94,32 +94,6 @@ class TestOpenApiEndpointAdapterMissingInfo():
           "query": "tag",
           "response_param_name_id": None,
           "id": 3
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "Integer",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "code",
-          "query": "code",
-          "response_param_name_id": None,
-          "id": 1,
-          "values": [
-            0
-          ]
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "String",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "message",
-          "query": "message",
-          "response_param_name_id": None,
-          "id": 2,
-          "values": [
-            ""
-          ]
         }
       ],
     }

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_oauth2_scopes_test.py
@@ -98,32 +98,6 @@ class TestOpenApiEndpointAdapterMissingOauthScopes():
           "query": "tag",
           "response_param_name_id": None,
           "id": 3
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "Integer",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "code",
-          "query": "code",
-          "response_param_name_id": None,
-          "id": 1,
-          "values": [
-            0
-          ]
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "String",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "message",
-          "query": "message",
-          "response_param_name_id": None,
-          "id": 2,
-          "values": [
-            ""
-          ]
         }
       ],
     }

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_missing_servers_test.py
@@ -94,32 +94,6 @@ class TestOpenApiEndpointAdapterMissingServers():
           "query": "tag",
           "response_param_name_id": None,
           "id": 3
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "Integer",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "code",
-          "query": "code",
-          "response_param_name_id": None,
-          "id": 1,
-          "values": [
-            0
-          ]
-        },
-        {
-          "endpoint_id": 1,
-          "inferred_type": "String",
-          "is_required": True,
-          "is_deterministic": True,
-          "name": "message",
-          "query": "message",
-          "response_param_name_id": None,
-          "id": 2,
-          "values": [
-            ""
-          ]
         }
       ],
     }

--- a/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
+++ b/stoobly_agent/test/app/cli/helpers/openapi_endpoint_adapter_test.py
@@ -141,28 +141,6 @@ class TestOpenApiEndpointAdapter():
             'response_param_name_id': 1,
             'values': [0]
           },
-          {
-            'endpoint_id': 1,
-            'id': 1,
-            'inferred_type': 'Integer',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'code',
-            'query': 'code',
-            'response_param_name_id': None,
-            'values': [0]
-          },
-          {
-            'endpoint_id': 1,
-            'id': 2,
-            'inferred_type': 'String',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'message',
-            'query': 'message',
-            'response_param_name_id': None,
-            'values': ['']
-          }
         ]
       }
 
@@ -241,28 +219,6 @@ class TestOpenApiEndpointAdapter():
               'response_param_name_id': None,
               'values': [0],
           },
-          {
-              'endpoint_id': 2,
-              'id': 1,
-              'inferred_type': 'Integer',
-              'is_deterministic': True,
-              'is_required': True,
-              'name': 'code',
-              'query': 'code',
-              'response_param_name_id': None,
-              'values': [0],
-          },
-          {
-              'endpoint_id': 2,
-              'id': 2,
-              'inferred_type': 'String',
-              'is_deterministic': True,
-              'is_required': True,
-              'name': 'message',
-              'query': 'message',
-              'response_param_name_id': None,
-              'values': [''],
-          },
         ],
       }
 
@@ -323,28 +279,6 @@ class TestOpenApiEndpointAdapter():
                 'response_param_name_id': None,
                 'values': [0],
             },
-            {
-                'endpoint_id': 3,
-                'id': 1,
-                'inferred_type': 'Integer',
-                'is_deterministic': True,
-                'is_required': True,
-                'name': 'code',
-                'query': 'code',
-                'response_param_name_id': None,
-                'values': [0],
-            },
-            {
-                'endpoint_id': 3,
-                'id': 2,
-                'inferred_type': 'String',
-                'is_deterministic': True,
-                'is_required': True,
-                'name': 'message',
-                'query': 'message',
-                'response_param_name_id': None,
-                'values': [''],
-            },
         ],
       }
 
@@ -370,30 +304,6 @@ class TestOpenApiEndpointAdapter():
           {
             'name': ':id',
             'type': 'alias',
-          },
-        ],
-        'response_param_names': [
-          {
-            'endpoint_id': 4,
-            'id': 1,
-            'inferred_type': 'Integer',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'code',
-            'query': 'code',
-            'response_param_name_id': None,
-            'values': [0],
-          },
-          {
-            'endpoint_id': 4,
-            'id': 2,
-            'inferred_type': 'String',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'message',
-            'query': 'message',
-            'response_param_name_id': None,
-            'values': [''],
           },
         ],
       }
@@ -708,30 +618,6 @@ class TestOpenApiEndpointAdapter():
             'type': 'static',
           },
         ],
-        'response_param_names': [
-          {
-            'endpoint_id': 1,
-            'id': 1,
-            'inferred_type': 'Integer',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'code',
-            'query': 'code',
-            'response_param_name_id': None,
-            'values': [0],
-          },
-          {
-            'endpoint_id': 1,
-            'id': 2,
-            'inferred_type': 'String',
-            'is_deterministic': True,
-            'is_required': True,
-            'name': 'message',
-            'query': 'message',
-            'response_param_name_id': None,
-            'values': [''],
-          },
-        ],
       }
 
     @pytest.fixture(scope='class')
@@ -859,31 +745,6 @@ class TestOpenApiEndpointAdapter():
               'type': 'static',
             },
           ],
-          'response_param_names': [
-            {
-              'endpoint_id': 2,
-              'id': 1,
-              'inferred_type': 'Integer',
-              'is_deterministic': True,
-              'is_required': True,
-              'name': 'code',
-              'query': 'code',
-              'response_param_name_id': None,
-              'values': [0],
-            },
-            {
-              'endpoint_id': 2,
-              'id': 2,
-              'inferred_type': 'String',
-              'is_deterministic': True,
-              'is_required': True,
-              'name': 'message',
-              'query': 'message',
-              'response_param_name_id': None,
-              'values': [''],
-            },
-          ],
-
         }
 
     def test_adapt_from_file(self, open_api_endpoint_adapter, petstore_references_file_path, expected_get_v1_pets_ref, expected_get_v2_pets_ref):


### PR DESCRIPTION
Changed response param extraction to only parse response schema for status code 200. Removes duplication issue for the following response param name:

```
{"name"=>"errorCode",  "inferred_type"=>"Hash", "query"=>"errorCode" }
```