### PR TITLE
Fix cert config folder always being created

### DIFF
--- a/stoobly_agent/config/data_dir.py
+++ b/stoobly_agent/config/data_dir.py
@@ -122,13 +122,13 @@ class DataDir:
                     options = json.loads(contents)
                     _conf_dir = options.get('confdir')
 
-                    if _conf_dir or not os.path.exists(_conf_dir):
+                    if _conf_dir and os.path.exists(_conf_dir):
                         conf_dir = _conf_dir
             except Exception:
                 pass
-
-        if not os.path.exists(conf_dir):
-            os.makedirs(conf_dir)
+        else:
+            if not os.path.exists(conf_dir):
+                os.makedirs(conf_dir)
 
         return conf_dir
 


### PR DESCRIPTION
Bug fix is to only create the folder if it doesn't exist or if the user specifies a custom path

Fixes: https://github.com/Stoobly/stoobly-agent/issues/280