### PR TITLE
Add "scaffold service delete" command

### DIFF
--- a/stoobly_agent/app/cli/scaffold/service_delete_command.py
+++ b/stoobly_agent/app/cli/scaffold/service_delete_command.py
@@ -1,0 +1,35 @@
+import glob
+import os
+import pdb
+import shutil
+
+from .app import App
+from .service_command import ServiceCommand
+from stoobly_agent.lib.logger import Logger
+
+
+LOG_ID = 'ServiceDeleteCommand'
+
+class ServiceDeleteCommand(ServiceCommand):
+  def __init__(self, app: App, **kwargs):
+    super().__init__(app, **kwargs)
+
+  def delete(self) -> None:
+    Logger.instance(LOG_ID).debug(f"Deleting service: {self.service_name}, path: {self.service_path}")
+
+    # Delete service directory
+    shutil.rmtree(self.service_path)
+
+    # Delete certs for that hostname if HTTPS
+    if self.service_config.scheme == 'https':
+      certs_dir_path_escaped = glob.escape(self.app.certs_dir_path)
+      hostname = self.service_config.hostname
+      pattern = os.path.join(certs_dir_path_escaped, f"{hostname}*")
+
+      cert_paths = glob.glob(pattern)
+      for cert_path in cert_paths:
+        Logger.instance(LOG_ID).debug(f"Deleting cert_path: {cert_path}")
+        os.remove(cert_path)
+
+    return None
+

--- a/stoobly_agent/app/cli/scaffold_cli.py
+++ b/stoobly_agent/app/cli/scaffold_cli.py
@@ -18,6 +18,7 @@ from stoobly_agent.app.cli.scaffold.docker.workflow.decorators_factory import ge
 from stoobly_agent.app.cli.scaffold.service import Service
 from stoobly_agent.app.cli.scaffold.service_config import ServiceConfig
 from stoobly_agent.app.cli.scaffold.service_create_command import ServiceCreateCommand
+from stoobly_agent.app.cli.scaffold.service_delete_command import ServiceDeleteCommand
 from stoobly_agent.app.cli.scaffold.service_workflow_validate_command import ServiceWorkflowValidateCommand
 from stoobly_agent.app.cli.scaffold.templates.constants import CORE_SERVICES
 from stoobly_agent.app.cli.scaffold.validate_exceptions import ScaffoldValidateException
@@ -142,6 +143,24 @@ def create(**kwargs):
     __scaffold_build(app, **kwargs)
   else:
     print(f"{service.dir_path} already exists, use option '--force' to continue")
+
+@service.command(
+  help="Delete a service",
+)
+@click.option('--app-dir-path', default=os.getcwd(), help='Path to application directory.')
+@click.argument('service_name')
+def delete(**kwargs):
+  __validate_app_dir(kwargs['app_dir_path'])
+
+  app = App(kwargs['app_dir_path'], DOCKER_NAMESPACE)
+  service = Service(kwargs['service_name'], app)
+
+  if not os.path.exists(service.dir_path):
+    print(f"Service does not exist, so not deleting")
+  else:
+    print(f"Deleting service: {service.service_name}")
+    __scaffold_delete(app, **kwargs)
+    print(f"Successfully deleted service: {service.service_name}")
 
 @service.command(
   help="Update a service config"
@@ -456,6 +475,11 @@ def __scaffold_build(app, **kwargs):
   command = ServiceCreateCommand(app, **kwargs)
 
   command.build()
+
+def __scaffold_delete(app, **kwargs):
+  command = ServiceDeleteCommand(app, **kwargs)
+
+  command.delete()
 
 def __validate_app_dir(app_dir_path):
   if not os.path.exists(app_dir_path):

--- a/stoobly_agent/test/app/cli/scaffold/cli_invoker.py
+++ b/stoobly_agent/test/app/cli/scaffold/cli_invoker.py
@@ -1,0 +1,134 @@
+import pathlib
+import pdb
+
+from click.testing import CliRunner
+
+from stoobly_agent.app.cli import scaffold
+from stoobly_agent.config.data_dir import DATA_DIR_NAME
+
+
+class ScaffoldCliInvoker():
+
+  @staticmethod
+  def cli_app_create(runner: CliRunner, app_dir_path: str, app_name: str):
+    pathlib.Path(f"{app_dir_path}/{DATA_DIR_NAME}").mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(scaffold, ['app', 'create',
+      '--app-dir-path', app_dir_path,
+      '--force',
+      app_name
+    ])
+
+    assert result.exit_code == 0
+    output = result.stdout
+    assert not output
+
+  @staticmethod
+  def cli_app_mkcert(runner: CliRunner, app_dir_path: str):
+    result = runner.invoke(scaffold, ['app', 'mkcert',
+      '--app-dir-path', app_dir_path,
+      '--context-dir-path', app_dir_path,
+    ])
+
+    assert result.exit_code == 0
+    output = result.stdout
+    assert not output
+
+  @staticmethod
+  def cli_service_create(runner: CliRunner, app_dir_path: str, hostname: str, service_name: str, https: bool):
+    scheme = 'http'
+    port = '80'
+    if https == True:
+      scheme = 'https'
+      port = '443'
+
+    result = runner.invoke(scaffold, ['service', 'create',
+      '--app-dir-path', app_dir_path,
+      '--env', 'TEST',
+      '--force',
+      '--hostname', hostname,
+      '--scheme', scheme,
+      '--port', port,
+      '--workflow', 'mock',
+      '--workflow', 'record',
+      '--workflow', 'test',
+      service_name
+    ])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert not output
+
+  # Specific flags for assets
+  @staticmethod
+  def cli_service_create_assets(runner: CliRunner, app_dir_path: str, hostname: str, service_name: str, https: bool):
+    scheme = 'http'
+    port = '80'
+    if https == True:
+      scheme = 'https'
+      port = '443'
+    proxy_mode_reverse_spec = f"reverse:{scheme}://{hostname}:8080"
+
+    result = runner.invoke(scaffold, ['service', 'create',
+      '--app-dir-path', app_dir_path,
+      '--force',
+      '--hostname', hostname,
+      '--scheme', scheme,
+      '--port', port,
+      '--proxy-mode', proxy_mode_reverse_spec,
+      '--detached',
+      '--workflow', 'test',
+      service_name
+    ])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert not output
+
+  @staticmethod
+  def cli_service_delete(runner: CliRunner, app_dir_path: str, service_name: str):
+    result = runner.invoke(scaffold, ['service', 'delete',
+      '--app-dir-path', app_dir_path,
+      service_name
+    ])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert 'error' not in output.lower()
+
+  @staticmethod
+  def cli_workflow_create(runner: CliRunner, app_dir_path: str, service_name: str):
+    result = runner.invoke(scaffold, ['workflow', 'create',
+      '--app-dir-path', app_dir_path,
+      '--service', service_name,
+      '--template', 'mock',
+      'ci',
+    ])
+
+    assert result.exit_code == 0
+    output = result.stdout
+    assert not output
+
+  @staticmethod
+  def cli_workflow_run(runner: CliRunner, app_dir_path: str, target_workflow_name: str):
+    command = ['workflow', 'run',
+      '--app-dir-path', app_dir_path,
+      '--context-dir-path', app_dir_path,
+      target_workflow_name,
+    ]
+    result = runner.invoke(scaffold, command)
+
+    assert result.exit_code == 0
+    output = result.stdout
+    assert output
+
+  @staticmethod
+  def cli_workflow_stop(runner: CliRunner, app_dir_path: str, target_workflow_name: str):
+    command = ['workflow', 'stop',
+      '--app-dir-path', app_dir_path,
+      '--context-dir-path', app_dir_path,
+      target_workflow_name,
+    ]
+    result = runner.invoke(scaffold, command)
+
+    assert result.exit_code == 0
+    output = result.stdout
+    assert output
+

--- a/stoobly_agent/test/app/cli/scaffold/cli_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/cli_test.py
@@ -1,0 +1,128 @@
+import os
+import pdb
+import shutil
+
+from click.testing import CliRunner
+import pytest
+
+from stoobly_agent.app.cli.scaffold.app import App
+from stoobly_agent.app.cli.scaffold.constants import (
+  DOCKER_NAMESPACE,
+  WORKFLOW_RECORD_TYPE,
+)
+from stoobly_agent.app.cli.scaffold.service_docker_compose import ServiceDockerCompose
+from stoobly_agent.config.data_dir import DataDir
+from stoobly_agent.test.app.cli.scaffold.e2e_test import ScaffoldCliInvoker
+from stoobly_agent.test.test_helper import reset
+
+
+class TestScaffoldCli():
+
+  @pytest.fixture(scope='module', autouse=True)
+  def settings(self):
+    return reset()
+
+  @pytest.fixture(scope='module')
+  def runner(self):
+    yield CliRunner()
+
+  @pytest.fixture(scope='class')
+  def app_name(self):
+    yield "0.0.1"
+
+  @pytest.fixture(scope='class', autouse=True)
+  def temp_dir(self):
+    data_dir_path = DataDir.instance().path
+    tmp_path = data_dir_path[:data_dir_path.rfind('/')]
+
+    yield tmp_path
+
+  @pytest.fixture(scope='class', autouse=True)
+  def app_dir_path(self, temp_dir, app_name):
+    yield temp_dir
+
+  @pytest.fixture(scope='class')
+  def hostname(self):
+    yield "http.badssl.com"
+
+  @pytest.fixture(scope='class')
+  def https_service_hostname(self):
+    yield "example.com"
+  
+  @pytest.fixture(scope='class')
+  def external_service_name(self):
+    yield "external-service"
+
+  @pytest.fixture(scope='class')
+  def external_https_service_name(self):
+    yield "external-https-service"
+
+  class TestServiceDelete():
+    @pytest.fixture(scope='class', autouse=True)
+    def target_workflow_name(self):
+      yield WORKFLOW_RECORD_TYPE
+
+    @pytest.fixture(scope='class')
+    def external_service_docker_compose(self, app_dir_path, target_workflow_name, external_service_name, hostname):
+      yield ServiceDockerCompose(app_dir_path=app_dir_path, target_workflow_name=target_workflow_name, service_name=external_service_name, hostname=hostname)
+    
+    @pytest.fixture(scope='class')
+    def external_https_service_docker_compose(self, app_dir_path, target_workflow_name, external_https_service_name, https_service_hostname):
+      yield ServiceDockerCompose(app_dir_path=app_dir_path, target_workflow_name=target_workflow_name, service_name=external_https_service_name, hostname=https_service_hostname)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def create_setup(self, runner, app_dir_path, app_name, external_service_docker_compose, external_https_service_docker_compose):
+      
+      ScaffoldCliInvoker.cli_app_create(runner, app_dir_path, app_name)
+
+      # Create external user defined services
+      ScaffoldCliInvoker.cli_service_create(runner, app_dir_path, external_service_docker_compose.hostname, external_service_docker_compose.service_name, False)
+      ScaffoldCliInvoker.cli_service_create(runner, app_dir_path, external_https_service_docker_compose.hostname, external_https_service_docker_compose.service_name, True)
+
+      # Generate certs
+      ScaffoldCliInvoker.cli_app_mkcert(runner, app_dir_path)
+    
+    @pytest.fixture(scope="class", autouse=True)
+    def cleanup_after_all(self, runner, app_dir_path, target_workflow_name):
+      yield
+      ScaffoldCliInvoker.cli_workflow_stop(runner, app_dir_path, target_workflow_name)
+      shutil.rmtree(app_dir_path)
+    
+ 
+    def test_service_delete(self, runner, app_dir_path, external_service_docker_compose):
+      app = App(app_dir_path, DOCKER_NAMESPACE)
+      service_name = external_service_docker_compose.service_name
+      
+      ScaffoldCliInvoker.cli_service_delete(runner, app_dir_path, service_name)
+
+      found = False
+      service_paths = app.service_paths
+      for service_path in service_paths:
+        if service_name in service_path:
+          found = True
+          break
+      if found:
+        assert False
+
+    def test_service_delete_https(self, runner, app_dir_path, external_https_service_docker_compose):
+      app = App(app_dir_path, DOCKER_NAMESPACE)
+      service_name = external_https_service_docker_compose.service_name
+      hostname = external_https_service_docker_compose.hostname
+
+      ScaffoldCliInvoker.cli_service_delete(runner, app_dir_path, service_name)
+
+      found = False
+      service_paths = app.service_paths
+      for service_path in service_paths:
+        if service_name in service_path:
+          found = True
+          break
+      if found:
+        assert False
+
+      # Certs should be deleted
+      certs_dir_path = os.listdir(app.certs_dir_path)
+      for cert_file in certs_dir_path:
+        if hostname in cert_file:
+          assert False
+


### PR DESCRIPTION
```
$ stoobly-agent scaffold service delete --help

Usage: stoobly-agent scaffold service delete [OPTIONS] SERVICE_NAME

  Delete a service

Options:
  --app-dir-path TEXT  Path to application directory.
  -h, --help           Show this message and exit.
```


- Add "scaffold service delete" command
- Move test CLI runner commands into new `ScaffoldCliInvoker` class
- Clean up unused variables