### PR TITLE
Enable log file handlers if it previously didn't exist

### DIFF
--- a/stoobly_agent/lib/intercepted_requests_logger.py
+++ b/stoobly_agent/lib/intercepted_requests_logger.py
@@ -341,6 +341,7 @@ class InterceptedRequestsLogger():
         file_path = cls.__get_file_path()
 
         if not os.path.exists(file_path):
+            cls.enable_logger_file()
             return
 
         try:


### PR DESCRIPTION
- Fixes bug where the log file won't get created if it didn't exist before
- This only effects new users of this feature