### PR TITLE
Fix minor bug of request logging OPTIONS as mock failures

### DIFF
--- a/stoobly_agent/app/proxy/handle_mock_service.py
+++ b/stoobly_agent/app/proxy/handle_mock_service.py
@@ -158,14 +158,12 @@ def __handle_mock_failure(context: MockContext) -> Union[None, 'MitmproxyRespons
     request = flow.request
     response = context.response
 
+    if request.method.upper() == 'OPTIONS':
+        # Default OPTIONS request to allow CORS
+        enable_cors(flow)
+        return flow.response
+
     InterceptedRequestsLogger.error("Mock failure", request=request, response=response)
-
-    if request.method.upper() != 'OPTIONS':
-        return
-
-    # Default OPTIONS request to allow CORS
-    enable_cors(flow)
-    return flow.response
 
 def __handle_found_policy(context: MockContext) -> None:
     req = context.flow.request


### PR DESCRIPTION
### Summary
Fix bug where OPTIONS requests were incorrectly logged as "Mock failure" at ERROR level in request log list output

OPTIONS requests are CORS pre-flight requests that don't need recorded mocks. They should be handled silently with a 200 CORS response which was already below the logging line.

Closes: https://github.com/Stoobly/stoobly-agent/issues/522