### PR TITLE
Rename commands to '[scaffold] request logs'

### DIFF
--- a/stoobly_agent/app/cli/request_cli.py
+++ b/stoobly_agent/app/cli/request_cli.py
@@ -173,7 +173,7 @@ def query(**kwargs):
   query_handler(kwargs)
 
 @click.group(
-  epilog="Run 'stoobly-agent request log COMMAND --help' for more information on a command.",
+  epilog="Run 'stoobly-agent request logs COMMAND --help' for more information on a command.",
   help="Manage intercepted requests logs"
 )
 @click.pass_context
@@ -209,4 +209,4 @@ def log_delete(**kwargs):
   SimpleInterceptedRequestsLogger.truncate(data_dir_path=context_dir_path)
 
 request.add_command(response)
-request.add_command(log)
+request.add_command(log, name='logs')

--- a/stoobly_agent/app/cli/scaffold/templates/app/.Makefile
+++ b/stoobly_agent/app/cli/scaffold/templates/app/.Makefile
@@ -116,8 +116,8 @@ intercept/enable:
 mock: workflow/mock workflow/up nameservers workflow/hostname/install workflow/up/run
 mock/down: workflow/mock workflow/down workflow/down/run workflow/hostname/uninstall
 mock/logs: workflow/mock workflow/logs workflow/logs/run
-mock/request/log/delete: workflow/mock workflow/request/log/delete
-mock/request/log/path: workflow/mock workflow/request/log/path
+mock/request/logs/delete: workflow/mock workflow/request/logs/delete
+mock/request/logs/path: workflow/mock workflow/request/logs/path
 mock/request/logs: workflow/mock workflow/request/logs
 mock/services: workflow/mock workflow/services
 pipx/install:
@@ -133,8 +133,8 @@ python/validate:
 record: workflow/record ca-cert/install workflow/up nameservers workflow/hostname/install workflow/up/run
 record/down: workflow/record workflow/down workflow/down/run workflow/hostname/uninstall
 record/logs: workflow/record workflow/logs workflow/logs/run
-record/request/log/delete: workflow/record workflow/request/log/delete
-record/request/log/path: workflow/record workflow/request/log/path
+record/request/logs/delete: workflow/record workflow/request/logs/delete
+record/request/logs/path: workflow/record workflow/request/logs/path
 record/request/logs: workflow/record workflow/request/logs
 record/services: workflow/record workflow/services
 scenario/create:
@@ -169,8 +169,8 @@ stoobly/install: python/validate pipx/install
 test: workflow/test workflow/up workflow/up/run
 test/down: workflow/test workflow/down workflow/down/run
 test/logs: workflow/test workflow/logs workflow/logs/run
-test/request/log/delete: workflow/test workflow/request/log/delete
-test/request/log/path: workflow/test workflow/request/log/path
+test/request/logs/delete: workflow/test workflow/request/logs/delete
+test/request/logs/path: workflow/test workflow/request/logs/path
 test/request/logs: workflow/test workflow/request/logs
 test/services: workflow/test workflow/services
 tmpdir:
@@ -201,10 +201,10 @@ workflow/namespace: tmpdir
 	@mkdir -p $(workflow_namespace_dir)
 workflow/record:
 	$(eval workflow=record)
-workflow/request/log/delete:
+workflow/request/logs/delete:
 	@export EXEC_COMMAND=request/log/.delete EXEC_OPTIONS="$(workflow_request_log_options) $(options)" EXEC_ARGS="$(workflow)" && \
 	$(stoobly_exec)
-workflow/request/log/path:
+workflow/request/logs/path:
 	@_ctx=$(context_dir) && \
 	_ctx_escaped=$$(printf '%s' "$$_ctx" | sed 's/[&|\\]/\\&/g') && \
 	export EXEC_COMMAND=request/log/.path EXEC_OPTIONS="$(workflow_request_log_options) $(options)" EXEC_ARGS="$(workflow)" && \

--- a/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.delete
+++ b/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.delete
@@ -3,4 +3,4 @@
 extra_options=$EXEC_OPTIONS
 workflow_name=$1
 
-stoobly-agent scaffold request log delete $workflow_name $extra_options
+stoobly-agent scaffold request logs delete $workflow_name $extra_options

--- a/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.list
+++ b/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.list
@@ -3,4 +3,4 @@
 extra_options=$EXEC_OPTIONS
 workflow_name=$1
 
-stoobly-agent scaffold request log list $workflow_name $extra_options
+stoobly-agent scaffold request logs list $workflow_name $extra_options

--- a/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.path
+++ b/stoobly_agent/app/cli/scaffold/templates/build/workflows/exec/request/log/.path
@@ -3,4 +3,4 @@
 extra_options=$EXEC_OPTIONS
 workflow_name=$1
 
-stoobly-agent scaffold request log path $workflow_name $extra_options
+stoobly-agent scaffold request logs path $workflow_name $extra_options

--- a/stoobly_agent/app/cli/scaffold_request_log_cli.py
+++ b/stoobly_agent/app/cli/scaffold_request_log_cli.py
@@ -16,7 +16,7 @@ def request(ctx):
 
 
 @click.group(
-  epilog="Run 'stoobly-agent scaffold request log COMMAND --help' for more information on a command.",
+  epilog="Run 'stoobly-agent scaffold request logs COMMAND --help' for more information on a command.",
   help="Manage intercepted requests logs for workflows"
 )
 @click.pass_context
@@ -76,4 +76,4 @@ def request_log_delete(**kwargs):
         workflow_namespace=workflow_namespace,
     )
 
-request.add_command(request_log, name="log")
+request.add_command(request_log, name="logs")

--- a/stoobly_agent/test/app/cli/request/request_log_test.py
+++ b/stoobly_agent/test/app/cli/request/request_log_test.py
@@ -37,7 +37,7 @@ class TestRequestLogCliParams:
     def test_log_list_calls_dump_logs(self, runner):
         """request log list calls dump_logs for non-scaffold use."""
         with patch.object(SimpleInterceptedRequestsLogger, 'dump_logs') as mock_dump:
-            result = runner.invoke(request, ['log', 'list'])
+            result = runner.invoke(request, ['logs', 'list'])
             assert result.exit_code == 0
             mock_dump.assert_called_once_with(
                 data_dir_path=DataDir.instance().context_dir_path,
@@ -51,14 +51,14 @@ class TestRequestLogCliParams:
     def test_log_delete_calls_truncate(self, runner):
         """request log delete calls truncate for non-scaffold use."""
         with patch.object(SimpleInterceptedRequestsLogger, 'truncate') as mock_truncate:
-            result = runner.invoke(request, ['log', 'delete'])
+            result = runner.invoke(request, ['logs', 'delete'])
             assert result.exit_code == 0
             mock_truncate.assert_called_once_with(data_dir_path=DataDir.instance().context_dir_path)
 
     def test_log_path_calls_get_log_file_path(self, runner):
         """request log path calls get_log_file_path for non-scaffold use."""
         with patch.object(SimpleInterceptedRequestsLogger, 'get_log_file_path') as mock_get:
-            result = runner.invoke(request, ['log', 'path'])
+            result = runner.invoke(request, ['logs', 'path'])
             assert result.exit_code == 0
             mock_get.assert_called_once_with(data_dir_path=DataDir.instance().context_dir_path)
 
@@ -164,7 +164,7 @@ class TestRequestLogE2e():
 
         time.sleep(0.5)
 
-        result = runner.invoke(request, ['log', 'list'])
+        result = runner.invoke(request, ['logs', 'list'])
         assert result.exit_code == 0
 
         output = result.output
@@ -191,20 +191,20 @@ class TestRequestLogE2e():
         )
         time.sleep(0.5)
 
-        result = runner.invoke(request, ['log', 'list'])
+        result = runner.invoke(request, ['logs', 'list'])
         assert result.exit_code == 0
         assert result.output.strip(), "Log should have entries before delete"
 
-        delete_result = runner.invoke(request, ['log', 'delete'])
+        delete_result = runner.invoke(request, ['logs', 'delete'])
         assert delete_result.exit_code == 0
 
-        list_result = runner.invoke(request, ['log', 'list'])
+        list_result = runner.invoke(request, ['logs', 'list'])
         assert list_result.exit_code == 0
         assert not list_result.output.strip(), f"Log should be empty after delete, got: {list_result.output}"
 
     def test_log_path_shows_correct_path(self, runner: CliRunner, proxy_pid):
         """Test that request log path outputs the correct simple log path."""
-        result = runner.invoke(request, ['log', 'path'])
+        result = runner.invoke(request, ['logs', 'path'])
         assert result.exit_code == 0
         assert 'tmp/logs/requests.json' in result.output
 
@@ -240,7 +240,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_method_via_cli(self):
         """Filter by method via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--method', 'GET'])
+        result = runner.invoke(request, ['logs', 'list', '--method', 'GET'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert '"method": "GET"' in result.output
@@ -251,7 +251,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_status_code_via_cli(self):
         """Filter by status code via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--status-code', '499'])
+        result = runner.invoke(request, ['logs', 'list', '--status-code', '499'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         assert '"status_code": 499' in result.output
@@ -260,7 +260,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_level_via_cli(self):
         """Filter by level via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--level', 'error'])
+        result = runner.invoke(request, ['logs', 'list', '--level', 'error'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         assert '"level": "ERROR"' in result.output
@@ -270,7 +270,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_message_via_cli(self):
         """Filter by message via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--message', 'Mock success'])
+        result = runner.invoke(request, ['logs', 'list', '--message', 'Mock success'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert 'Mock failure' not in result.output
@@ -280,7 +280,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_scenario_key_via_cli(self):
         """Filter by scenario key via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--scenario-key', 'sk-2'])
+        result = runner.invoke(request, ['logs', 'list', '--scenario-key', 'sk-2'])
         assert result.exit_code == 0
         assert '"scenario_key": "sk-2"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -289,7 +289,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_url_via_cli(self):
         """Filter by URL substring via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--url', '/api/users'])
+        result = runner.invoke(request, ['logs', 'list', '--url', '/api/users'])
         assert result.exit_code == 0
         assert 'https://example.com/api/users' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -298,7 +298,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_request_key_via_cli(self):
         """Filter by request key via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--request-key', 'rk-1'])
+        result = runner.invoke(request, ['logs', 'list', '--request-key', 'rk-1'])
         assert result.exit_code == 0
         assert '"request_key": "rk-1"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -307,7 +307,7 @@ class TestRequestLogListFiltering:
     def test_filter_by_test_title_via_cli(self):
         """Filter by test title via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--test-title', 'Create User'])
+        result = runner.invoke(request, ['logs', 'list', '--test-title', 'Create User'])
         assert result.exit_code == 0
         assert '"test_title": "Create User"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -316,7 +316,7 @@ class TestRequestLogListFiltering:
     def test_multiple_filters_via_cli(self):
         """Multiple filters via CLI."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list', '--method', 'POST', '--level', 'ERROR'])
+        result = runner.invoke(request, ['logs', 'list', '--method', 'POST', '--level', 'ERROR'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -325,7 +325,7 @@ class TestRequestLogListFiltering:
     def test_no_filters_returns_all(self):
         """No filters returns all entries."""
         runner = CliRunner()
-        result = runner.invoke(request, ['log', 'list'])
+        result = runner.invoke(request, ['logs', 'list'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert 'Mock failure' in result.output

--- a/stoobly_agent/test/app/cli/request/scaffold_request_log_test.py
+++ b/stoobly_agent/test/app/cli/request/scaffold_request_log_test.py
@@ -114,7 +114,7 @@ class TestRequestLogE2e():
         time.sleep(0.5)
 
         # Invoke scaffold request log list
-        result = runner.invoke(scaffold, ['request', 'log', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
         assert result.exit_code == 0
 
         output = result.output
@@ -147,16 +147,16 @@ class TestRequestLogE2e():
         InterceptedRequestsLogger.shutdown()
 
         # Verify log has entries
-        result = runner.invoke(scaffold, ['request', 'log', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
         assert result.exit_code == 0
         assert result.output.strip(), "Log should have entries before delete"
 
         # Delete log entries
-        delete_result = runner.invoke(scaffold, ['request', 'log', 'delete', target_workflow_name, '--context-dir-path', app_dir_path])
+        delete_result = runner.invoke(scaffold, ['request', 'logs', 'delete', target_workflow_name, '--context-dir-path', app_dir_path])
         assert delete_result.exit_code == 0
 
         # Verify log is now empty
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
         assert not list_result.output.strip(), f"Log should be empty after delete, got: {list_result.output}"
 
@@ -240,7 +240,7 @@ class TestRequestLogWithRecordedRequestsE2e():
     def test_successful_mock_logged_at_info_level(self, app_dir_path, record_then_mock_workflow, runner: CliRunner, proxy_url: str):
         """Test that successful mock requests are logged at INFO level (default)."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
 
         # Make the recorded request - should succeed with mocked response
         res = requests.get(
@@ -252,7 +252,7 @@ class TestRequestLogWithRecordedRequestsE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         if res.status_code != 200:
@@ -279,7 +279,7 @@ class TestRequestLogWithRecordedRequestsE2e():
     def test_unrecorded_request_logged_as_error(self, app_dir_path, record_then_mock_workflow, runner: CliRunner, proxy_url: str):
         """Test that unrecorded requests in mock mode are logged as errors."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
 
         # Make an unrecorded request - should trigger 499
         res = requests.get(
@@ -292,7 +292,7 @@ class TestRequestLogWithRecordedRequestsE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         # Should have a Mock failure entry
@@ -304,7 +304,7 @@ class TestRequestLogWithRecordedRequestsE2e():
     def test_options_request_not_logged_as_failure(self, app_dir_path, record_then_mock_workflow, runner: CliRunner, proxy_url: str):
         """Test that OPTIONS requests are not logged as mock failures."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
 
         # Make an OPTIONS request - should get CORS response, not logged as failure
         res = requests.options(
@@ -319,7 +319,7 @@ class TestRequestLogWithRecordedRequestsE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_MOCK_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         # Should NOT have a Mock failure entry for OPTIONS request
@@ -407,7 +407,7 @@ class TestRequestLogWithTestWorkflowE2e():
     def test_successful_test_logged_at_info_level(self, app_dir_path, record_then_test_workflow, runner: CliRunner, proxy_url: str):
         """Test that successful test requests are logged at INFO level."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
 
         # Make the recorded request - should succeed with test comparison
         res = requests.get(
@@ -419,7 +419,7 @@ class TestRequestLogWithTestWorkflowE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         if res.status_code != 200:
@@ -445,7 +445,7 @@ class TestRequestLogWithTestWorkflowE2e():
     def test_unrecorded_request_logged_as_test_failure(self, app_dir_path, record_then_test_workflow, runner: CliRunner, proxy_url: str):
         """Test that unrecorded requests in test mode are logged as test failures."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
 
         # Make an unrecorded request - should trigger test failure
         res = requests.get(
@@ -458,7 +458,7 @@ class TestRequestLogWithTestWorkflowE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         # Should have a Mock failure entry (test workflow uses mock mode)
@@ -470,7 +470,7 @@ class TestRequestLogWithTestWorkflowE2e():
     def test_options_request_not_logged_as_test_failure(self, app_dir_path, record_then_test_workflow, runner: CliRunner, proxy_url: str):
         """Test that OPTIONS requests are not logged as test failures."""
         # Clear log first
-        runner.invoke(scaffold, ['request', 'log', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
 
         # Make an OPTIONS request - should get CORS response, not logged as failure
         res = requests.options(
@@ -485,7 +485,7 @@ class TestRequestLogWithTestWorkflowE2e():
         time.sleep(0.5)
         InterceptedRequestsLogger.shutdown()
 
-        list_result = runner.invoke(scaffold, ['request', 'log', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
+        list_result = runner.invoke(scaffold, ['request', 'logs', 'list', WORKFLOW_TEST_TYPE, '--namespace', WORKFLOW_TEST_TYPE, '--context-dir-path', app_dir_path])
         assert list_result.exit_code == 0
 
         # Should NOT have a Mock failure entry for OPTIONS request
@@ -572,7 +572,7 @@ class TestRequestLogFromDifferentWorkingDirectory():
         With --context-dir-path pointing to the correct location, logs are retrieved.
         """
         # Clear any existing logs
-        runner.invoke(scaffold, ['request', 'log', 'delete', target_workflow_name, '--context-dir-path', app_dir_path])
+        runner.invoke(scaffold, ['request', 'logs', 'delete', target_workflow_name, '--context-dir-path', app_dir_path])
 
         # Make a request to generate log entries
         res = requests.get(
@@ -601,13 +601,13 @@ class TestRequestLogFromDifferentWorkingDirectory():
             DataDir._instances = None
 
             # Without --context-dir-path, logs should not be found (empty output or error)
-            result_without_flag = runner.invoke(scaffold, ['request', 'log', 'list', target_workflow_name])
+            result_without_flag = runner.invoke(scaffold, ['request', 'logs', 'list', target_workflow_name])
             # The output should be empty because there's no .stoobly in different_working_dir
             assert not result_without_flag.output.strip() or 'Mock failure' not in result_without_flag.output, \
                 "Logs should NOT be found without --context-dir-path from a different directory"
 
             # With --context-dir-path, logs SHOULD be found
-            result_with_flag = runner.invoke(scaffold, ['request', 'log', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
+            result_with_flag = runner.invoke(scaffold, ['request', 'logs', 'list', target_workflow_name, '--context-dir-path', app_dir_path])
             assert result_with_flag.exit_code == 0
             assert result_with_flag.output.strip(), "Logs should be found with --context-dir-path"
 
@@ -636,7 +636,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_list_without_args_uses_defaults(self, runner):
         """scaffold request log list with workflow_name passes None for namespace."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'dump_logs') as mock_dump:
-            result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock'])
             assert result.exit_code == 0
             mock_dump.assert_called_once()
             call_kwargs = mock_dump.call_args.kwargs
@@ -648,7 +648,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_delete_without_args_uses_defaults(self, runner):
         """scaffold request log delete with workflow_name passes None for namespace."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'truncate') as mock_truncate:
-            result = runner.invoke(scaffold, ['request', 'log', 'delete', 'mock'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'delete', 'mock'])
             assert result.exit_code == 0
             mock_truncate.assert_called_once()
             call_kwargs = mock_truncate.call_args.kwargs
@@ -660,7 +660,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_list_accepts_workflow_name_argument(self, runner):
         """scaffold request log list accepts workflow_name as positional argument."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'dump_logs') as mock_dump:
-            result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock'])
             assert result.exit_code == 0
             mock_dump.assert_called_once()
             call_kwargs = mock_dump.call_args.kwargs
@@ -672,7 +672,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_list_accepts_namespace_option(self, runner):
         """scaffold request log list accepts --namespace option."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'dump_logs') as mock_dump:
-            result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--namespace', 'test-ns'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--namespace', 'test-ns'])
             assert result.exit_code == 0
             mock_dump.assert_called_once()
             call_kwargs = mock_dump.call_args.kwargs
@@ -684,7 +684,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_list_accepts_both_workflow_and_namespace(self, runner):
         """scaffold request log list accepts both workflow_name and --namespace."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'dump_logs') as mock_dump:
-            result = runner.invoke(scaffold, ['request', 'log', 'list', 'record', '--namespace', 'prod'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'list', 'record', '--namespace', 'prod'])
             assert result.exit_code == 0
             mock_dump.assert_called_once()
             call_kwargs = mock_dump.call_args.kwargs
@@ -696,7 +696,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_delete_accepts_workflow_name_argument(self, runner):
         """scaffold request log delete accepts workflow_name as positional argument."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'truncate') as mock_truncate:
-            result = runner.invoke(scaffold, ['request', 'log', 'delete', 'mock'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'delete', 'mock'])
             assert result.exit_code == 0
             mock_truncate.assert_called_once()
             call_kwargs = mock_truncate.call_args.kwargs
@@ -708,7 +708,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_delete_accepts_namespace_option(self, runner):
         """scaffold request log delete accepts --namespace option."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'truncate') as mock_truncate:
-            result = runner.invoke(scaffold, ['request', 'log', 'delete', 'mock', '--namespace', 'test-ns'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'delete', 'mock', '--namespace', 'test-ns'])
             assert result.exit_code == 0
             mock_truncate.assert_called_once()
             call_kwargs = mock_truncate.call_args.kwargs
@@ -720,7 +720,7 @@ class TestScaffoldRequestLogCliParams:
     def test_log_delete_accepts_both_workflow_and_namespace(self, runner):
         """scaffold request log delete accepts both workflow_name and --namespace."""
         with patch.object(ScaffoldInterceptedRequestsLogger, 'truncate') as mock_truncate:
-            result = runner.invoke(scaffold, ['request', 'log', 'delete', 'record', '--namespace', 'prod'])
+            result = runner.invoke(scaffold, ['request', 'logs', 'delete', 'record', '--namespace', 'prod'])
             assert result.exit_code == 0
             mock_truncate.assert_called_once()
             call_kwargs = mock_truncate.call_args.kwargs
@@ -764,7 +764,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_method_via_cli(self):
         """Filter by method via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--method', 'GET'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--method', 'GET'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert '"method": "GET"' in result.output
@@ -774,7 +774,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_status_code_via_cli(self):
         """Filter by status code via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--status-code', '499'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--status-code', '499'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         assert '"status_code": 499' in result.output
@@ -783,7 +783,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_level_via_cli(self):
         """Filter by level via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--level', 'error'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--level', 'error'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         assert '"level": "ERROR"' in result.output
@@ -793,7 +793,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_message_via_cli(self):
         """Filter by message via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--message', 'Mock success'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--message', 'Mock success'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert 'Mock failure' not in result.output
@@ -803,7 +803,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_scenario_key_via_cli(self):
         """Filter by scenario key via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--scenario-key', 'sk-2'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--scenario-key', 'sk-2'])
         assert result.exit_code == 0
         assert '"scenario_key": "sk-2"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -812,7 +812,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_url_via_cli(self):
         """Filter by URL substring via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--url', '/api/users'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--url', '/api/users'])
         assert result.exit_code == 0
         assert 'https://example.com/api/users' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -821,7 +821,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_request_key_via_cli(self):
         """Filter by request key via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--request-key', 'rk-1'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--request-key', 'rk-1'])
         assert result.exit_code == 0
         assert '"request_key": "rk-1"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -830,7 +830,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_test_title_via_cli(self):
         """Filter by test title via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--test-title', 'Create User'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--test-title', 'Create User'])
         assert result.exit_code == 0
         assert '"test_title": "Create User"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -839,7 +839,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_multiple_filters_via_cli(self):
         """Multiple filters via CLI."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--method', 'POST', '--level', 'ERROR'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--method', 'POST', '--level', 'ERROR'])
         assert result.exit_code == 0
         assert 'Mock failure' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -848,7 +848,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_no_filters_returns_all(self):
         """No filters returns all entries."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock'])
         assert result.exit_code == 0
         assert 'Mock success' in result.output
         assert 'Mock failure' in result.output
@@ -858,7 +858,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_filter_by_service_name_via_cli(self):
         """Filter by service name via CLI (scaffold-specific filter)."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--service-name', 'svc-b'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--service-name', 'svc-b'])
         assert result.exit_code == 0
         assert '"service_name": "svc-b"' in result.output
         lines = [line for line in result.output.strip().split('\n') if line]
@@ -867,7 +867,7 @@ class TestScaffoldRequestLogListFiltering:
     def test_namespace_is_routing_not_filter(self):
         """--namespace routes to the correct log file; it is not a content filter."""
         runner = CliRunner()
-        result = runner.invoke(scaffold, ['request', 'log', 'list', 'mock', '--namespace', 'ns-1'])
+        result = runner.invoke(scaffold, ['request', 'logs', 'list', 'mock', '--namespace', 'ns-1'])
         assert result.exit_code == 0
         lines = [line for line in result.output.strip().split('\n') if line]
         assert len(lines) == 3


### PR DESCRIPTION
## Overview
This PR renames the log subcommand to logs across the CLI. This change ensures that the command name follows the pluralization convention used for other resource-based commands in the stoobly-agent.

## Changes

### CLI Command Renaming:
Updated `stoobly-agent request log` to `stoobly-agent request logs`.
Updated `stoobly-agent scaffold request log` to `stoobly-agent scaffold request logs`.

### Documentation & Help Text:
Updated epilog messages in [request_cli.py](code-assist-path:/home/matt/Downloads/github/stoobly/stoobly-agent/stoobly_agent/app/cli/request_cli.py) and [scaffold_request_log_cli.py](code-assist-path:/home/matt/Downloads/github/stoobly/stoobly-agent/stoobly_agent/app/cli/scaffold_request_log_cli.py) to point to the new logs command.

### Updated help strings for the command groups.
Test Updates:
Adjusted E2E tests in [request_log_test.py](code-assist-path:/home/matt/Downloads/github/stoobly/stoobly-agent/stoobly_agent/test/app/cli/request/request_log_test.py) and [scaffold_request_log_test.py](code-assist-path:/home/matt/Downloads/github/stoobly/stoobly-agent/stoobly_agent/test/app/cli/request/scaffold_request_log_test.py) to invoke the logs command instead of log.

Closes #564