### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/stoobly_agent/app/api/application_http_request_handler.py
+++ b/stoobly_agent/app/api/application_http_request_handler.py
@@ -16,7 +16,8 @@ class ApplicationHTTPRequestHandler(SimpleHTTPRequestHandler):
 
     @property
     def public_dir(self):
-        return os.path.join(self.ROOT_DIR, 'public')
+        # Normalize the public directory to ensure consistent path comparisons
+        return os.path.normpath(os.path.join(self.ROOT_DIR, 'public'))
 
     ### Method handlers
 

--- a/stoobly_agent/app/api/simple_http_request_handler.py
+++ b/stoobly_agent/app/api/simple_http_request_handler.py
@@ -28,8 +28,22 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
         path = kwargs['file']
 
+        # If a public directory is defined (as in ApplicationHTTPRequestHandler),
+        # ensure that the requested path stays within that directory.
+        if hasattr(self, 'public_dir'):
+            base_dir = os.path.normpath(self.public_dir)
+            normalized_path = os.path.normpath(path)
+            if not normalized_path.startswith(base_dir):
+                kwargs['status'] = 404
+                kwargs['data'] = b''
+                self.render_data(kwargs)
+                return
+
         if not os.path.exists(path):
             kwargs['status'] = 404
+            kwargs['data'] = b''
+            self.render_data(kwargs)
+            return
 
         mimetype = mimetypes.guess_type(path)[0]
         kwargs['headers']['Content-Type'] = mimetype or 'text/plain'


### PR DESCRIPTION
Potential fix for [https://github.com/Stoobly/stoobly-agent/security/code-scanning/3](https://github.com/Stoobly/stoobly-agent/security/code-scanning/3)

General approach: Ensure any path derived from user input is (1) normalized, (2) resolved under a known safe root directory, and (3) verified to remain inside that directory before being used with `open` or other filesystem operations. Centralize this check so all call sites of `render_file` benefit.

Best concrete fix here:

1. In `ApplicationHTTPRequestHandler.public_dir`, normalize the returned path so the same canonical form is used for comparisons.
2. In `ApplicationHTTPRequestHandler.do_GET`, keep the basic logic but ensure the prefix check uses a normalized path. (It already does this; keeping it is fine.)
3. In `SimpleHTTPRequestHandler.render_file`, add a defensive check: if `self` has a `public_dir` attribute (which `ApplicationHTTPRequestHandler` does), normalize both `public_dir` and the requested `path`, and ensure the normalized path starts with the normalized `public_dir`. If not, respond with 404 and do not open the file. This ensures:
   - Existing `do_GET` behavior remains the same for valid paths.
   - Even if `render_file` is called from somewhere else with a tainted path, it still cannot escape the `public_dir`.
4. Also in `render_file`, gracefully handle nonexistent files by returning early after setting the status, so we do not try to open a missing path.

Concretely:

- File `stoobly_agent/app/api/application_http_request_handler.py`:
  - Modify the `public_dir` property (lines 17–20) to return `os.path.normpath(os.path.join(self.ROOT_DIR, 'public'))`. This ensures consistency with later comparisons and with `render_file`’s new check.

- File `stoobly_agent/app/api/simple_http_request_handler.py`:
  - Inside `render_file`, after `path = kwargs['file']`, add a block that:
    - Checks `hasattr(self, 'public_dir')`.
    - Computes `base_dir = os.path.normpath(self.public_dir)`.
    - Computes `normalized_path = os.path.normpath(path)`.
    - If `not normalized_path.startswith(base_dir)`, set `kwargs['status'] = 404`, set an empty body (e.g., `kwargs['data'] = b''`), and call `self.render_data(kwargs)` then `return`.
  - Adjust the nonexistent file handling so that if `not os.path.exists(path)`, we set `kwargs['status'] = 404`, set `kwargs['data'] = b''`, and call `self.render_data(kwargs)` and `return`, instead of falling through and attempting to open the file.

No new imports are required beyond `os`, which is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
