### PR TITLE
Upgrade filelock from 3.19.1 to 3.25.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -774,14 +774,14 @@ text-unidecode = "1.2"
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
+version = "3.25.1"
 description = "A platform independent file lock."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"},
-    {file = "filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"},
+    {file = "filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf"},
+    {file = "filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9"},
 ]
 
 [[package]]
@@ -2847,4 +2847,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "1fda3f275364bf450f15e5b1344c65dc19e7abf177b732b2eb87ba1406bad857"
+content-hash = "7f4f83a6b8f38b83c65078238c70b2f226232a3b8a0815ff9160bb9b09944184"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ stoobly_orator = ">=0.9.12"
 tabulate = ">=0.8.8"
 watchdog = ">=6.0.0,<=6.1.0"
 yamale = ">=6.0.0,<=7.0.0"
-filelock = "^3.19.1"
+filelock = "^3.25.1"
 
 [tool.poetry.group.test.dependencies]
 mock = ">=5.0.0"


### PR DESCRIPTION
Resolves CVE-2026-22701 and CVE-2025-68146