### PR TITLE
Fix SyntaxWarning for escape sequence

### DIFF
--- a/stoobly_agent/test/app/proxy/mitmproxy/request_facade_test.py
+++ b/stoobly_agent/test/app/proxy/mitmproxy/request_facade_test.py
@@ -136,7 +136,7 @@ class TestRewriteParams():
     }
     rewrite_rule = RewriteRule({
       'methods': ['POST'],
-      'pattern': '.*?/users(?:\?.*)?',
+      'pattern': r'.*?/users(?:\?.*)?',
       'parameter_rules': [parameter_rule]
     })
 

--- a/stoobly_agent/test/app/proxy/mitmproxy/request_facade_test.py
+++ b/stoobly_agent/test/app/proxy/mitmproxy/request_facade_test.py
@@ -96,7 +96,7 @@ class TestRewriteParams():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'parameter_rules': [parameter_rule]
     })
 
@@ -116,7 +116,7 @@ class TestRewriteParams():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'parameter_rules': [parameter_rule]
     })
 
@@ -158,7 +158,7 @@ class TestRewriteUrl():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'url_rules': [url_rule]
     })
 
@@ -179,7 +179,7 @@ class TestRewriteUrl():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'url_rules': [url_rule]
     })
 
@@ -202,7 +202,7 @@ class TestRewriteUrl():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'url_rules': [url_rule]
     })
 
@@ -225,7 +225,7 @@ class TestRewriteUrl():
     }
     rewrite_rule = RewriteRule({
       'methods': ['GET'],
-      'pattern': '.*?/requests(?:\?.*)?',
+      'pattern': r'.*?/requests(?:\?.*)?',
       'url_rules': [url_rule]
     })
 
@@ -255,7 +255,7 @@ class TestRewriteUrl():
       }
       rewrite_rule = RewriteRule({
         'methods': ['GET'],
-        'pattern': '.*?/requests(?:\?.*)?',
+        'pattern': r'.*?/requests(?:\?.*)?',
         'url_rules': [url_rule1, url_rule2]
       })
 


### PR DESCRIPTION
## Fix SyntaxWarning: invalid escape sequence in regex patterns

Python 3.12+ raises SyntaxWarning for invalid escape sequences in regular strings. The test file request_facade_test.py used `'.*?/requests(?:\?.*)?'` where `\?` is not a valid Python escape sequence.

Change: Convert 7 regex pattern strings from regular strings to raw strings (r'...') so backslashes are passed literally to the regex engine rather than interpreted as Python escape sequences.

Closes https://github.com/Stoobly/stoobly-agent/issues/634