### PR TITLE
Add tests for scaffold service CLI commands (create, delete, list, show)

### DIFF
--- a/stoobly_agent/test/app/cli/scaffold/service/service_create_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/service/service_create_test.py
@@ -1,0 +1,225 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from stoobly_agent.app.cli.scaffold_cli import scaffold
+from stoobly_agent.app.cli.scaffold.app import App
+from stoobly_agent.app.cli.scaffold.constants import (
+    WORKFLOW_MOCK_TYPE,
+    WORKFLOW_RECORD_TYPE,
+    WORKFLOW_TEST_TYPE,
+)
+from stoobly_agent.app.cli.scaffold.service import Service
+from stoobly_agent.app.cli.scaffold.service_config import ServiceConfig
+from stoobly_agent.test.app.cli.scaffold.local.cli_invoker import LocalScaffoldCliInvoker
+from stoobly_agent.test.test_helper import reset
+
+
+class TestScaffoldServiceCreate:
+
+    @pytest.fixture(scope='module', autouse=True)
+    def settings(self):
+        return reset()
+
+    @pytest.fixture(scope='module')
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture(scope='class')
+    def temp_dir(self):
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture(scope='class')
+    def app_name(self):
+        return 'test-app'
+
+    @pytest.fixture(scope='class')
+    def app_dir_path(self, temp_dir, app_name):
+        return os.path.join(temp_dir, app_name)
+
+    @pytest.fixture(scope='class', autouse=True)
+    def create_scaffold_app(self, runner: CliRunner, app_dir_path: str, app_name: str):
+        LocalScaffoldCliInvoker.cli_app_create(runner, app_dir_path, app_name)
+        yield
+
+    class TestCreateBasicService:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'basic-service'
+
+        def test_create_basic_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--quiet',
+                service_name,
+            ])
+
+            assert result.exit_code == 0
+
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            assert os.path.exists(service.dir_path)
+
+    class TestCreateWithHostname:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'hostname-service'
+
+        @pytest.fixture(scope='class')
+        def hostname(self):
+            return 'example.com'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str, hostname: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--hostname', hostname,
+                '--quiet',
+                service_name,
+            ])
+            assert result.exit_code == 0
+
+        def test_hostname_is_set(self, app_dir_path: str, service_name: str, hostname: str):
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            service_config = ServiceConfig(service.dir_path)
+            assert service_config.hostname == hostname
+
+    class TestCreateWithPort:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'port-service'
+
+        @pytest.fixture(scope='class')
+        def port(self):
+            return 8080
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str, port: int):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--port', str(port),
+                '--quiet',
+                service_name,
+            ])
+            assert result.exit_code == 0
+
+        def test_port_is_set(self, app_dir_path: str, service_name: str, port: int):
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            service_config = ServiceConfig(service.dir_path)
+            assert service_config.port == port
+
+    class TestCreateWithScheme:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'scheme-service'
+
+        @pytest.fixture(scope='class')
+        def scheme(self):
+            return 'https'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str, scheme: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--scheme', scheme,
+                '--quiet',
+                service_name,
+            ])
+            assert result.exit_code == 0
+
+        def test_scheme_is_set(self, app_dir_path: str, service_name: str, scheme: str):
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            service_config = ServiceConfig(service.dir_path)
+            assert service_config.scheme == scheme
+
+    class TestCreateWithSingleWorkflow:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'workflow-service'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--workflow', WORKFLOW_MOCK_TYPE,
+                '--quiet',
+                service_name,
+            ])
+            assert result.exit_code == 0
+
+        def test_workflow_dir_exists(self, app_dir_path: str, service_name: str):
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            assert os.path.exists(service.workflow_dir_path(WORKFLOW_MOCK_TYPE))
+
+    class TestCreateWithMultipleWorkflows:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'multi-workflow-service'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--workflow', WORKFLOW_MOCK_TYPE,
+                '--workflow', WORKFLOW_RECORD_TYPE,
+                '--workflow', WORKFLOW_TEST_TYPE,
+                '--quiet',
+                service_name,
+            ])
+            assert result.exit_code == 0
+
+        def test_all_workflow_dirs_exist(self, app_dir_path: str, service_name: str):
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            for workflow in [WORKFLOW_MOCK_TYPE, WORKFLOW_RECORD_TYPE, WORKFLOW_TEST_TYPE]:
+                assert os.path.exists(service.workflow_dir_path(workflow))
+
+    class TestCreateInvalidCases:
+
+        def test_invalid_port_fails(self, runner: CliRunner, app_dir_path: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--port', '70000',
+                'invalid-port-service',
+            ])
+            assert result.exit_code != 0
+
+        def test_invalid_scheme_fails(self, runner: CliRunner, app_dir_path: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--scheme', 'ftp',
+                'invalid-scheme-service',
+            ])
+            assert result.exit_code != 0
+
+        def test_invalid_workflow_fails(self, runner: CliRunner, app_dir_path: str):
+            result = runner.invoke(scaffold, [
+                'service', 'create',
+                '--app-dir-path', app_dir_path,
+                '--workflow', 'invalid-workflow',
+                'invalid-workflow-service',
+            ])
+            assert result.exit_code != 0

--- a/stoobly_agent/test/app/cli/scaffold/service/service_delete_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/service/service_delete_test.py
@@ -1,0 +1,77 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from stoobly_agent.app.cli.scaffold_cli import scaffold
+from stoobly_agent.app.cli.scaffold.app import App
+from stoobly_agent.app.cli.scaffold.service import Service
+from stoobly_agent.test.app.cli.scaffold.local.cli_invoker import LocalScaffoldCliInvoker
+from stoobly_agent.test.test_helper import reset
+
+
+class TestScaffoldServiceDelete:
+
+    @pytest.fixture(scope='module', autouse=True)
+    def settings(self):
+        return reset()
+
+    @pytest.fixture(scope='module')
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture(scope='class')
+    def temp_dir(self):
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture(scope='class')
+    def app_name(self):
+        return 'test-app'
+
+    @pytest.fixture(scope='class')
+    def app_dir_path(self, temp_dir, app_name):
+        return os.path.join(temp_dir, app_name)
+
+    @pytest.fixture(scope='class', autouse=True)
+    def create_scaffold_app(self, runner: CliRunner, app_dir_path: str, app_name: str):
+        LocalScaffoldCliInvoker.cli_app_create(runner, app_dir_path, app_name)
+        yield
+
+    class TestDeleteExistingService:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'delete-me-service'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            LocalScaffoldCliInvoker.cli_service_create(runner, app_dir_path, 'delete-me.example.com', service_name, False)
+
+        def test_delete_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            result = runner.invoke(scaffold, [
+                'service', 'delete',
+                '--app-dir-path', app_dir_path,
+                service_name,
+            ])
+
+            assert result.exit_code == 0
+
+            app = App(app_dir_path)
+            service = Service(service_name, app)
+            assert not os.path.exists(service.dir_path)
+
+    class TestDeleteNonExistentService:
+
+        def test_delete_nonexistent_service_is_noop(self, runner: CliRunner, app_dir_path: str):
+            result = runner.invoke(scaffold, [
+                'service', 'delete',
+                '--app-dir-path', app_dir_path,
+                'does-not-exist',
+            ])
+
+            assert result.exit_code == 0
+            assert 'does not exist' in result.output

--- a/stoobly_agent/test/app/cli/scaffold/service/service_list_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/service/service_list_test.py
@@ -1,0 +1,75 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from stoobly_agent.app.cli.scaffold_cli import scaffold
+from stoobly_agent.test.app.cli.scaffold.local.cli_invoker import LocalScaffoldCliInvoker
+from stoobly_agent.test.test_helper import reset
+
+
+class TestScaffoldServiceList:
+
+    @pytest.fixture(scope='module', autouse=True)
+    def settings(self):
+        return reset()
+
+    @pytest.fixture(scope='module')
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture(scope='class')
+    def temp_dir(self):
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture(scope='class')
+    def app_name(self):
+        return 'test-app'
+
+    @pytest.fixture(scope='class')
+    def app_dir_path(self, temp_dir, app_name):
+        return os.path.join(temp_dir, app_name)
+
+    @pytest.fixture(scope='class')
+    def service_name_1(self):
+        return 'list-service-one'
+
+    @pytest.fixture(scope='class')
+    def service_name_2(self):
+        return 'list-service-two'
+
+    @pytest.fixture(scope='class', autouse=True)
+    def create_scaffold_app(self, runner: CliRunner, app_dir_path: str, app_name: str, service_name_1: str, service_name_2: str):
+        LocalScaffoldCliInvoker.cli_app_create(runner, app_dir_path, app_name)
+        LocalScaffoldCliInvoker.cli_service_create(runner, app_dir_path, 'service-one.example.com', service_name_1, False)
+        LocalScaffoldCliInvoker.cli_service_create(runner, app_dir_path, 'service-two.example.com', service_name_2, False)
+        yield
+
+    class TestListAll:
+
+        def test_list_returns_all_services(self, runner: CliRunner, app_dir_path: str, service_name_1: str, service_name_2: str):
+            result = runner.invoke(scaffold, [
+                'service', 'list',
+                '--app-dir-path', app_dir_path,
+            ])
+
+            assert result.exit_code == 0
+            assert service_name_1 in result.output
+            assert service_name_2 in result.output
+
+    class TestListWithFilter:
+
+        def test_list_filters_by_service_name(self, runner: CliRunner, app_dir_path: str, service_name_1: str, service_name_2: str):
+            result = runner.invoke(scaffold, [
+                'service', 'list',
+                '--app-dir-path', app_dir_path,
+                '--service', service_name_1,
+            ])
+
+            assert result.exit_code == 0
+            assert service_name_1 in result.output
+            assert service_name_2 not in result.output

--- a/stoobly_agent/test/app/cli/scaffold/service/service_show_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/service/service_show_test.py
@@ -1,0 +1,72 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from stoobly_agent.app.cli.scaffold_cli import scaffold
+from stoobly_agent.test.app.cli.scaffold.local.cli_invoker import LocalScaffoldCliInvoker
+from stoobly_agent.test.test_helper import reset
+
+
+class TestScaffoldServiceShow:
+
+    @pytest.fixture(scope='module', autouse=True)
+    def settings(self):
+        return reset()
+
+    @pytest.fixture(scope='module')
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture(scope='class')
+    def temp_dir(self):
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture(scope='class')
+    def app_name(self):
+        return 'test-app'
+
+    @pytest.fixture(scope='class')
+    def app_dir_path(self, temp_dir, app_name):
+        return os.path.join(temp_dir, app_name)
+
+    @pytest.fixture(scope='class', autouse=True)
+    def create_scaffold_app(self, runner: CliRunner, app_dir_path: str, app_name: str):
+        LocalScaffoldCliInvoker.cli_app_create(runner, app_dir_path, app_name)
+        yield
+
+    class TestShowExistingService:
+
+        @pytest.fixture(scope='class')
+        def service_name(self):
+            return 'show-service'
+
+        @pytest.fixture(scope='class', autouse=True)
+        def create_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            LocalScaffoldCliInvoker.cli_service_create(runner, app_dir_path, 'show.example.com', service_name, False)
+
+        def test_show_service(self, runner: CliRunner, app_dir_path: str, service_name: str):
+            result = runner.invoke(scaffold, [
+                'service', 'show',
+                '--app-dir-path', app_dir_path,
+                service_name,
+            ])
+
+            assert result.exit_code == 0
+            assert service_name in result.output
+
+    class TestShowNonExistentService:
+
+        def test_show_nonexistent_service_shows_nothing(self, runner: CliRunner, app_dir_path: str):
+            result = runner.invoke(scaffold, [
+                'service', 'show',
+                '--app-dir-path', app_dir_path,
+                'does-not-exist',
+            ])
+
+            assert result.exit_code == 0
+            assert 'does-not-exist' not in result.output

--- a/stoobly_agent/test/app/cli/scaffold/service/service_show_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/service/service_show_test.py
@@ -18,7 +18,7 @@ class TestScaffoldServiceShow:
 
     @pytest.fixture(scope='module')
     def runner(self):
-        return CliRunner()
+        return CliRunner(mix_stderr=False)
 
     @pytest.fixture(scope='class')
     def temp_dir(self):


### PR DESCRIPTION
## Summary

- Adds test coverage for `scaffold service create` with options: basic creation, `--hostname`, `--port`, `--scheme`, single workflow, and multiple workflows
- Adds tests for `scaffold service delete` covering service deletion
- Adds tests for `scaffold service list` verifying services appear after creation
- Adds tests for `scaffold service show` verifying service details are displayed

## Test plan

- [x] `poetry run pytest stoobly_agent/test/app/cli/scaffold/service/service_create_test.py`
- [x] `poetry run pytest stoobly_agent/test/app/cli/scaffold/service/service_delete_test.py`
- [x] `poetry run pytest stoobly_agent/test/app/cli/scaffold/service/service_list_test.py`
- [x] `poetry run pytest stoobly_agent/test/app/cli/scaffold/service/service_show_test.py`

Closes: https://github.com/Stoobly/stoobly-agent/issues/643