### PR TITLE
651 command scaffold workflow rewrite

### DIFF
--- a/docs/scaffold-workflow-rewrite.md
+++ b/docs/scaffold-workflow-rewrite.md
@@ -1,0 +1,75 @@
+# `scaffold workflow rewrite`
+
+## What it does
+
+`stoobly-agent scaffold workflow rewrite` syncs replay rewrite rules for services in a workflow.
+
+For each selected service, if upstream URL components differ from the service URL (hostname, port, or scheme), the command upserts a rewrite rule so replay traffic is rewritten from the service URL to the upstream URL.
+
+In practice, this keeps replay routing aligned with service-level `UPSTREAM_*` settings after scaffold config changes.
+
+## Command
+
+```bash
+stoobly-agent scaffold workflow rewrite [OPTIONS] WORKFLOW_NAME
+```
+
+### Options
+
+- `--app-dir-path TEXT` Path to application directory.
+- `--containerized` Set if run from within a container.
+- `--context-dir-path TEXT` Path to Stoobly data directory.
+- `--service TEXT` Select specific services. Defaults to all services in the workflow.
+
+## How rewrite rules are generated
+
+For each service:
+
+1. Resolve service URL from service config.
+2. Compare service URL parts with effective upstream values.
+3. If any of `hostname`, `port`, or `scheme` differs, persist a rewrite rule with:
+   - pattern: `{service_url}/?.*?`
+   - methods: `GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `OPTIONS`
+   - mode: `REPLAY`
+   - destination: upstream hostname/port/scheme
+
+If a service has no URL, no rewrite rule is created for that service.
+
+## Workflow template behavior
+
+Rewrite rules are keyed by workflow template when a workflow is custom-templated.  
+The command resolves template with:
+
+- `workflow template` when present
+- otherwise `WORKFLOW_NAME`
+
+This means custom workflows inherit rewrite behavior from their template type.
+
+## Docker test workflow exception
+
+When runtime is Docker, local services in the `test` workflow are skipped.
+
+This avoids adding replay rewrites for local test services where upstream hostname is expected to be `host.docker.internal`.
+
+## Examples
+
+Rewrite all services in the `record` workflow:
+
+```bash
+stoobly-agent scaffold workflow rewrite record
+```
+
+Rewrite one service only:
+
+```bash
+stoobly-agent scaffold workflow rewrite --service payments-api record
+```
+
+Run from a containerized context:
+
+```bash
+stoobly-agent scaffold workflow rewrite \
+  --containerized \
+  --context-dir-path /home/stoobly/.stoobly \
+  record
+```

--- a/stoobly_agent/app/cli/scaffold/docker/service/gateway_base.py
+++ b/stoobly_agent/app/cli/scaffold/docker/service/gateway_base.py
@@ -104,11 +104,29 @@ class GatewayBase():
           self.with_traefik_config(gateway_base)
         else:
           self.with_run_options(gateway_base)
+          self.with_extra_hosts_for_local_services(gateway_base)
 
         self.with_networks(hostnames, gateway_base) 
 
     with open(docker_compose_dest_path, 'w') as fp:
       yaml.dump(compose, fp) 
+
+  def with_extra_hosts_for_local_services(self, gateway_base: dict):
+    """Map host.docker.internal to the host gateway when any workflow service is local (forward proxy only)."""
+    if self.proxy_mode == PROXY_MODE_REVERSE:
+      return
+
+    for path in self.service_paths:
+      config = ServiceConfig(path)
+      if not config.local:
+        continue
+
+      host_mapping = 'host.docker.internal:host-gateway'
+      if 'extra_hosts' not in gateway_base:
+        gateway_base['extra_hosts'] = []
+      if host_mapping not in gateway_base['extra_hosts']:
+        gateway_base['extra_hosts'].append(host_mapping)
+      return
 
   def with_run_options(self, compose: dict):
     def handle_before_entrypoint(public_directory_paths, response_fixtures_paths, lifecycle_hooks_paths):
@@ -134,20 +152,6 @@ class GatewayBase():
     if self.commands:
       workflow_name = self.commands[0].workflow_name
       compose['env_file'] = [f'{workflow_name}/.env']
-
-  def __to_traefik_log_level(self):
-    log_level = self.log_level
-
-    if log_level == 'debug':
-      log_level = 'DEBUG'
-    elif log_level == 'warning':
-      log_level = 'WARN'
-    elif log_level == 'error':
-      log_level = 'ERROR'
-    else:
-      log_level = 'INFO'
-
-    return log_level
 
   def with_traefik_config(self, compose: dict):
     config_dest = '/etc/traefik/traefik.yml'
@@ -235,3 +239,17 @@ class GatewayBase():
         hostnames.append(config.hostname) 
 
     return hostnames, ports
+
+  def __to_traefik_log_level(self):
+    log_level = self.log_level
+
+    if log_level == 'debug':
+      log_level = 'DEBUG'
+    elif log_level == 'warning':
+      log_level = 'WARN'
+    elif log_level == 'error':
+      log_level = 'ERROR'
+    else:
+      log_level = 'INFO'
+
+    return log_level

--- a/stoobly_agent/app/cli/scaffold/docker/workflow/decorators_factory.py
+++ b/stoobly_agent/app/cli/scaffold/docker/workflow/decorators_factory.py
@@ -16,8 +16,8 @@ def get_workflow_decorators(workflow: str, service_config: ServiceConfig):
         workflow_decorators.append(ReverseProxyDecorator)
         workflow_decorators.append(DnsDecorator)
 
-      if service_config.local:
-        workflow_decorators.append(LocalDecorator)
+        if service_config.local:
+          workflow_decorators.append(LocalDecorator)
   elif workflow == WORKFLOW_MOCK_TYPE or workflow == WORKFLOW_TEST_TYPE:
      if service_config.hostname:
       if service_config.app_config.proxy_mode == PROXY_MODE_REVERSE:

--- a/stoobly_agent/app/cli/scaffold/rewrite.py
+++ b/stoobly_agent/app/cli/scaffold/rewrite.py
@@ -1,0 +1,37 @@
+from stoobly_agent.app.cli.helpers.set_rewrite_rule_service import set_rewrite_rule
+from stoobly_agent.app.cli.scaffold.constants import WORKFLOW_TEST_TYPE
+from stoobly_agent.app.cli.scaffold.service_config import ServiceConfig
+from stoobly_agent.app.settings import Settings
+from stoobly_agent.config.constants import method, mode
+from stoobly_agent.lib.api.keys.project_key import ProjectKey
+
+def apply_upstream_url_rewrite(service_config: ServiceConfig, workflow_name: str) -> None:
+  """
+  If effective upstream hostname, port, or scheme differs from the service's public
+  hostname, port, or scheme, persist a replay-mode URL rewrite rule mapping the service URL to upstream.
+  """
+  if not service_config.url:
+    return
+
+  upstream_hostname = service_config.upstream_hostname
+  upstream_port = service_config.upstream_port
+  upstream_scheme = service_config.upstream_scheme
+
+  if (
+    upstream_hostname != service_config.hostname
+    or upstream_port != service_config.port
+    or upstream_scheme != service_config.scheme
+  ):
+    settings: Settings = Settings.instance()
+    project_key = ProjectKey(settings.proxy.intercept.project_key)
+    set_rewrite_rule(
+      project_key.id,
+      pattern=f'{service_config.url}/?.*?',
+      method=[method.GET, method.PATCH, method.POST, method.PUT, method.DELETE, method.OPTIONS],
+      mode=[mode.REPLAY],
+      hostname=upstream_hostname,
+      port=upstream_port,
+      scheme=upstream_scheme,
+    )
+
+

--- a/stoobly_agent/app/cli/scaffold/rewrite.py
+++ b/stoobly_agent/app/cli/scaffold/rewrite.py
@@ -5,7 +5,7 @@ from stoobly_agent.app.settings import Settings
 from stoobly_agent.config.constants import method, mode
 from stoobly_agent.lib.api.keys.project_key import ProjectKey
 
-def apply_upstream_url_rewrite(service_config: ServiceConfig, workflow_name: str) -> None:
+def apply_upstream_url_rewrite(service_config: ServiceConfig) -> None:
   """
   If effective upstream hostname, port, or scheme differs from the service's public
   hostname, port, or scheme, persist a replay-mode URL rewrite rule mapping the service URL to upstream.

--- a/stoobly_agent/app/cli/scaffold/run.py
+++ b/stoobly_agent/app/cli/scaffold/run.py
@@ -2,13 +2,8 @@ import os
 
 from typing import List, Callable
 
-from stoobly_agent.app.cli.helpers.set_rewrite_rule_service import set_rewrite_rule
 from stoobly_agent.app.cli.scaffold.app_config import AppConfig
 from stoobly_agent.app.cli.scaffold.workflow_run_command import WorkflowRunCommand
-from stoobly_agent.app.settings import Settings
-from stoobly_agent.config.constants import method, mode
-from stoobly_agent.lib.api.keys.project_key import ProjectKey
-
 def iter_commands(
   commands: List[WorkflowRunCommand],
   handle_before_entrypoint: Callable = None,
@@ -79,25 +74,6 @@ def iter_commands(
   for command in commands:
     if handle_command:
       handle_command(command)
-
-    upstream_hostname = command.service_config.upstream_hostname
-    upstream_port = command.service_config.upstream_port
-    upstream_scheme = command.service_config.upstream_scheme
-
-    # If upstream hostname, port, scheme, or url is different from service hostname, port, scheme, or url,
-    # update settings rewrite rules to rewrite url to upstream url
-    if upstream_hostname != command.service_config.hostname or upstream_port != command.service_config.port or upstream_scheme != command.service_config.scheme:
-      settings: Settings = Settings.instance()
-      project_key = ProjectKey(settings.proxy.intercept.project_key)
-      set_rewrite_rule(
-        project_key.id,
-        pattern=f'{command.service_config.url}/?.*?',
-        method=[method.GET, method.PATCH, method.POST, method.PUT, method.DELETE, method.OPTIONS],
-        mode=[mode.REPLAY],
-        hostname=upstream_hostname,
-        port=upstream_port,
-        scheme=upstream_scheme
-      )
 
     # If second from last command, run up_command i.e. right before entrypoint
     if len(commands) >= 2 and command == commands[-2]:

--- a/stoobly_agent/app/cli/scaffold/service_config.py
+++ b/stoobly_agent/app/cli/scaffold/service_config.py
@@ -140,8 +140,6 @@ class ServiceConfig(Config):
     else:
       v = int(v)
       if v > 0 and v <= 65535:
-        if v == self.__upstream_port and self.local:
-          raise ValueError('port cannot be the same as upstream port')
         self.__port = v
 
   @property
@@ -201,8 +199,6 @@ class ServiceConfig(Config):
     else:
       v = int(v)
       if v > 0 and v <= 65535:
-        if v == self.__port and self.local:
-          raise ValueError('upstream port cannot be the same as port')
         self.__upstream_port = v
       else:
         raise ValueError('upstream port must be between 0 and 65535')

--- a/stoobly_agent/app/cli/scaffold/templates/build/services/build/mock/.init
+++ b/stoobly_agent/app/cli/scaffold/templates/build/services/build/mock/.init
@@ -19,6 +19,9 @@ stoobly-agent intercept enable
 if [ "$APP_PROXY_MODE" = "forward" ]; then
   echo "Configuring firewall..."
   stoobly-agent scaffold workflow firewall "$WORKFLOW_NAME"
+
+  echo "Configuring rewrite..."
+  stoobly-agent scaffold workflow rewrite "$WORKFLOW_NAME"
 fi
 
 entrypoint=$1

--- a/stoobly_agent/app/cli/scaffold/templates/build/services/build/record/.init
+++ b/stoobly_agent/app/cli/scaffold/templates/build/services/build/record/.init
@@ -18,6 +18,9 @@ stoobly-agent intercept configure --mode record --policy all
 if [ "$APP_PROXY_MODE" = "forward" ]; then
   echo "Configuring firewall..."
   stoobly-agent scaffold workflow firewall "$WORKFLOW_NAME"
+
+  echo "Configuring rewrite..."
+  stoobly-agent scaffold workflow rewrite "$WORKFLOW_NAME"
 fi
 
 echo "Configuring UI..."

--- a/stoobly_agent/app/cli/scaffold/templates/build/services/build/test/.init
+++ b/stoobly_agent/app/cli/scaffold/templates/build/services/build/test/.init
@@ -19,6 +19,9 @@ stoobly-agent intercept enable
 if [ "$APP_PROXY_MODE" = "forward" ]; then
   echo "Configuring firewall..."
   stoobly-agent scaffold workflow firewall "$WORKFLOW_NAME"
+
+  echo "Configuring rewrite..."
+  stoobly-agent scaffold workflow rewrite "$WORKFLOW_NAME"
 fi
 
 entrypoint=$1

--- a/stoobly_agent/app/cli/scaffold/validate_command.py
+++ b/stoobly_agent/app/cli/scaffold/validate_command.py
@@ -60,7 +60,7 @@ class ValidateCommand():
         sleep(1)
         return self.validate_init_containers(init_container_name, retry + 1)
 
-      init_exit_message = f"{bcolors.FAIL}init container {init_container_name} exited with: {init_container.attrs['State']['ExitCode']}{bcolors.ENDC}"
+      init_exit_message = f"{bcolors.FAIL}init container {init_container_name} {init_container.status} with: {init_container.attrs['State']['ExitCode']}{bcolors.ENDC}"
       suggestion_message = f"{bcolors.BOLD}Run 'docker logs {init_container_name}'{bcolors.ENDC}"
       error_message = f"{init_exit_message}\n\n{suggestion_message}"
 

--- a/stoobly_agent/app/cli/scaffold/workflow_validate_command.py
+++ b/stoobly_agent/app/cli/scaffold/workflow_validate_command.py
@@ -1,9 +1,10 @@
 import os
 import pdb
 import socket
-from typing import Optional
+import time
 
 from docker import errors as docker_errors
+from typing import Optional
 
 from stoobly_agent.app.cli.scaffold.constants import WORKFLOW_TEST_TYPE
 from stoobly_agent.app.cli.scaffold.managed_services_docker_compose import (
@@ -59,7 +60,7 @@ class WorkflowValidateCommand(WorkflowCommand, ValidateCommand):
     except docker_errors.NotFound:
       raise ScaffoldValidateException(error_message)
 
-  def validate_mock_ui_service(self):
+  def validate_mock_ui_service(self, retry: int = 0):
     if self.app_config.runtime_local:
       return
     
@@ -87,6 +88,10 @@ class WorkflowValidateCommand(WorkflowCommand, ValidateCommand):
     try:
       mock_ui_container = self.docker_client.containers.get(mock_ui_container_name)
       if not mock_ui_container or (mock_ui_container.status != 'running'):
+        if retry < 1:
+          time.sleep(1)
+          return self.validate_mock_ui_service(retry + 1)
+
         raise ScaffoldValidateException(mock_ui_missing_error_message)
     except docker_errors.NotFound:
       raise ScaffoldValidateException(mock_ui_missing_error_message)

--- a/stoobly_agent/app/cli/scaffold_cli.py
+++ b/stoobly_agent/app/cli/scaffold_cli.py
@@ -17,6 +17,7 @@ from stoobly_agent.app.cli.scaffold.constants import (
 )
 from stoobly_agent.app.cli.scaffold.docker.workflow.decorators_factory import get_workflow_decorators
 from stoobly_agent.app.cli.scaffold.hosts_file_manager import HostsFileManager
+from stoobly_agent.app.cli.scaffold.rewrite import apply_upstream_url_rewrite
 from stoobly_agent.app.cli.scaffold.service import Service
 from stoobly_agent.app.cli.scaffold.service_config import ServiceConfig
 from stoobly_agent.app.cli.scaffold.service_create_command import ServiceCreateCommand
@@ -715,6 +716,25 @@ def mkcert(**kwargs):
   __services_mkcert(app, services)
 
 @workflow.command(
+  help="Sync replay rewrite rules from service upstream hostname, port, and scheme"
+)
+@click.option('--app-dir-path', default=context_dir_path, help='Path to application directory.')
+@click.option('--containerized', is_flag=True, help='Set if run from within a container.')
+@click.option('--context-dir-path', default=data_dir.context_dir_path, help='Path to Stoobly data directory.')
+@click.option('--service', multiple=True, help='Select specific services. Defaults to all.')
+@click.argument('workflow_name')
+def rewrite(**kwargs):
+  containerized = kwargs['containerized']
+  app = App(context_dir_path, **kwargs) if containerized else App(kwargs['app_dir_path'], **kwargs)
+
+  __validate_app(app)
+
+  services = __get_services(
+    app, service=kwargs['service'], without_core=True, workflow=[kwargs['workflow_name']]
+  )
+  __services_rewrite(app, services, kwargs['workflow_name'])
+
+@workflow.command(
   help="Configure include firewall rules for workflow service(s)"
 )
 @click.option('--app-dir-path', default=context_dir_path, help='Path to application directory.')
@@ -1099,6 +1119,24 @@ def __services_mkcert(app: App, services):
     if not ca.signed(hostname, app.certs_dir_path):
       Logger.instance(LOG_ID).info(f"Creating cert for {hostname}")
       ca.sign(hostname, app.certs_dir_path)
+
+def __services_rewrite(app: App, services, workflow_name: str):
+  workflow_dir_path = service.workflow_dir_path(workflow_name)
+  workflow_config = WorkflowConfig(workflow_dir_path)
+  workflow_template = workflow_config.template or workflow_name
+
+  for service_name in services:
+    service = Service(service_name, app)
+    __validate_service_dir(service.dir_path)
+
+    # Skip rewrite for docker runtime local services in test workflows
+    # In such a case, UPSTREAM_HOSTNAME will be set to host.docker.internal
+    service_config = ServiceConfig(service.dir_path)
+    if app.config.runtime == RUNTIME_DOCKER:
+      if service_config.local and workflow_name == WORKFLOW_TEST_TYPE:
+        continue
+
+    apply_upstream_url_rewrite(service_config, workflow_template)
 
 def __services_firewall(app: App, services, workflow_name: str):
   settings = Settings.instance()

--- a/stoobly_agent/app/cli/scaffold_cli.py
+++ b/stoobly_agent/app/cli/scaffold_cli.py
@@ -1121,22 +1121,25 @@ def __services_mkcert(app: App, services):
       ca.sign(hostname, app.certs_dir_path)
 
 def __services_rewrite(app: App, services, workflow_name: str):
-  workflow_dir_path = service.workflow_dir_path(workflow_name)
-  workflow_config = WorkflowConfig(workflow_dir_path)
-  workflow_template = workflow_config.template or workflow_name
-
   for service_name in services:
     service = Service(service_name, app)
     __validate_service_dir(service.dir_path)
 
+    workflow_dir_path = service.workflow_dir_path(workflow_name)
+    workflow_config = WorkflowConfig(workflow_dir_path)
+    workflow_template = workflow_config.template or workflow_name
+
     # Skip rewrite for docker runtime local services in test workflows
     # In such a case, UPSTREAM_HOSTNAME will be set to host.docker.internal
     service_config = ServiceConfig(service.dir_path)
-    if app.config.runtime == RUNTIME_DOCKER:
-      if service_config.local and workflow_name == WORKFLOW_TEST_TYPE:
-        continue
+    if (
+      workflow_template == WORKFLOW_TEST_TYPE and
+      service_config.local and
+      service_config.app_config.runtime == RUNTIME_DOCKER
+    ):
+      continue
 
-    apply_upstream_url_rewrite(service_config, workflow_template)
+    apply_upstream_url_rewrite(service_config)
 
 def __services_firewall(app: App, services, workflow_name: str):
   settings = Settings.instance()

--- a/stoobly_agent/app/cli/setting_cli.py
+++ b/stoobly_agent/app/cli/setting_cli.py
@@ -23,7 +23,7 @@ from .helpers.print_service import FORMATS, print_projects, print_scenarios, sel
 from .helpers.set_rewrite_rule_service import set_rewrite_rule
 from .helpers.validations import *
 
-LOG_ID = 'ConfigCLI'
+LOG_ID = 'SettingCLI'
 
 settings = Settings.instance()
 is_remote = settings.cli.features.remote or not not os.environ.get(env_vars.FEATURE_REMOTE)

--- a/stoobly_agent/test/app/cli/cli_commands_test.py
+++ b/stoobly_agent/test/app/cli/cli_commands_test.py
@@ -66,6 +66,7 @@ class TestCliSubcommandsLoad:
         ['scaffold', 'workflow', 'firewall'],
         ['scaffold', 'workflow', 'logs'],
         ['scaffold', 'workflow', 'mkcert'],
+        ['scaffold', 'workflow', 'rewrite'],
         ['scaffold', 'workflow', 'show'],
         ['scaffold', 'workflow', 'up'],
         ['scaffold', 'workflow', 'validate'],

--- a/stoobly_agent/test/app/cli/scaffold/docker/gateway_base_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/docker/gateway_base_test.py
@@ -1,10 +1,25 @@
 import pytest
+import yaml
 
 from unittest.mock import MagicMock
 
 from stoobly_agent.app.cli.scaffold.app_config import AppConfig
-from stoobly_agent.app.cli.scaffold.constants import PROXY_MODE_FORWARD
+from stoobly_agent.app.cli.scaffold.constants import (
+  APP_PROXY_MODE_ENV,
+  APP_PROXY_PORT_ENV,
+  APP_RUNTIME_ENV,
+  PROXY_MODE_FORWARD,
+  RUNTIME_DOCKER,
+  SERVICE_HOSTNAME_ENV,
+  SERVICE_LOCAL_ENV,
+  SERVICE_NAME_ENV,
+  SERVICE_PORT_ENV,
+  SERVICE_SCHEME_ENV,
+  SERVICES_NAMESPACE,
+)
+from stoobly_agent.app.cli.scaffold.docker.constants import DOCKER_COMPOSE_BASE
 from stoobly_agent.app.cli.scaffold.docker.service.gateway_base import GatewayBase
+from stoobly_agent.app.cli.scaffold.templates.constants import CORE_GATEWAY_SERVICE_NAME
 from stoobly_agent.app.cli.scaffold.workflow_namespace import WorkflowNamespace
 
 
@@ -68,3 +83,118 @@ class TestGatewayBaseWithRunOptions():
       "gateway_base compose missing env_file — WORKFLOW_NAME won't be set in the container"
     )
     assert compose['env_file'] == [f'{workflow_name}/.env']
+
+
+class TestGatewayBaseExtraHostsForLocal():
+
+  @pytest.fixture
+  def workflow_name(self):
+    return 'record'
+
+  def test_configure_adds_extra_hosts_when_forward_and_local_service(self, tmp_path, workflow_name):
+    scaffold = tmp_path / 'scaffold'
+    (scaffold / 'gateway').mkdir(parents=True)
+    (scaffold / 'myservice').mkdir(parents=True)
+    runtime_root = tmp_path / 'runtime'
+    (runtime_root / SERVICES_NAMESPACE / CORE_GATEWAY_SERVICE_NAME).mkdir(parents=True)
+
+    with open(scaffold / '.config.yml', 'w') as f:
+      yaml.dump(
+        {
+          APP_PROXY_MODE_ENV: PROXY_MODE_FORWARD,
+          APP_RUNTIME_ENV: RUNTIME_DOCKER,
+          APP_PROXY_PORT_ENV: 8080,
+        },
+        f,
+      )
+
+    with open(scaffold / 'myservice' / '.config.yml', 'w') as f:
+      yaml.dump(
+        {
+          SERVICE_HOSTNAME_ENV: 'api.example.test',
+          SERVICE_PORT_ENV: 4000,
+          SERVICE_SCHEME_ENV: 'http',
+          SERVICE_LOCAL_ENV: True,
+          SERVICE_NAME_ENV: 'myservice',
+        },
+        f,
+      )
+
+    with open(scaffold / 'gateway' / '.docker-compose.base.template.yml', 'w') as f:
+      yaml.dump({'services': {'gateway_base': {'image': 'busybox'}}}, f)
+
+    wf_ns = MagicMock(spec=WorkflowNamespace)
+    wf_ns.app.runtime_app_data_dir.path = str(runtime_root)
+
+    app_config = AppConfig(str(scaffold))
+    gb = GatewayBase(wf_ns, [str(scaffold / 'myservice')])
+    gb.with_app_config(app_config)
+    gb.no_publish = True
+
+    stub = MagicMock()
+    stub.workflow_name = workflow_name
+    stub.service_config = MagicMock(url=None)
+    gb.with_commands([stub])
+
+    gb.configure()
+
+    out_path = runtime_root / SERVICES_NAMESPACE / CORE_GATEWAY_SERVICE_NAME / DOCKER_COMPOSE_BASE
+    assert out_path.is_file()
+    with open(out_path) as f:
+      out = yaml.safe_load(f)
+    gateway_svc = out['services']['gateway_base']
+    assert 'extra_hosts' in gateway_svc
+    assert 'host.docker.internal:host-gateway' in gateway_svc['extra_hosts']
+
+  def test_configure_skips_extra_hosts_when_no_local_service(self, tmp_path, workflow_name):
+    scaffold = tmp_path / 'scaffold2'
+    (scaffold / 'gateway').mkdir(parents=True)
+    (scaffold / 'remote').mkdir(parents=True)
+    runtime_root = tmp_path / 'runtime2'
+    (runtime_root / SERVICES_NAMESPACE / CORE_GATEWAY_SERVICE_NAME).mkdir(parents=True)
+
+    with open(scaffold / '.config.yml', 'w') as f:
+      yaml.dump(
+        {
+          APP_PROXY_MODE_ENV: PROXY_MODE_FORWARD,
+          APP_RUNTIME_ENV: RUNTIME_DOCKER,
+          APP_PROXY_PORT_ENV: 8080,
+        },
+        f,
+      )
+
+    with open(scaffold / 'remote' / '.config.yml', 'w') as f:
+      yaml.dump(
+        {
+          SERVICE_HOSTNAME_ENV: 'api.example.test',
+          SERVICE_PORT_ENV: 4000,
+          SERVICE_SCHEME_ENV: 'http',
+          SERVICE_NAME_ENV: 'remote',
+        },
+        f,
+      )
+
+    with open(scaffold / 'gateway' / '.docker-compose.base.template.yml', 'w') as f:
+      yaml.dump({'services': {'gateway_base': {'image': 'busybox'}}}, f)
+
+    wf_ns = MagicMock(spec=WorkflowNamespace)
+    wf_ns.app.runtime_app_data_dir.path = str(runtime_root)
+
+    app_config = AppConfig(str(scaffold))
+    gb = GatewayBase(wf_ns, [str(scaffold / 'remote')])
+    gb.with_app_config(app_config)
+    gb.no_publish = True
+
+    stub = MagicMock()
+    stub.workflow_name = workflow_name
+    stub.service_config = MagicMock(url=None)
+    gb.with_commands([stub])
+
+    gb.configure()
+
+    out_path = runtime_root / SERVICES_NAMESPACE / CORE_GATEWAY_SERVICE_NAME / DOCKER_COMPOSE_BASE
+    with open(out_path) as f:
+      out = yaml.safe_load(f)
+    gateway_svc = out['services']['gateway_base']
+    extra = gateway_svc.get('extra_hosts') or []
+    assert 'host.docker.internal:host-gateway' not in extra

--- a/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from stoobly_agent.app.cli.scaffold.constants import WORKFLOW_RECORD_TYPE, WORKFLOW_TEST_TYPE
+from stoobly_agent.app.cli.scaffold.rewrite import apply_upstream_url_rewrite
+import stoobly_agent.app.cli.scaffold.rewrite as rewrite_module
+
+
+def _settings_with_project_id(project_id: str = "project-id"):
+  return SimpleNamespace(
+    proxy=SimpleNamespace(
+      intercept=SimpleNamespace(
+        project_key=f"org/{project_id}"
+      )
+    )
+  )
+
+
+def _service_config(**overrides):
+  config = SimpleNamespace(
+    url="https://api.example.test",
+    local=False,
+    hostname="api.example.test",
+    port=443,
+    scheme="https",
+    upstream_hostname="upstream.example.test",
+    upstream_port=8443,
+    upstream_scheme="https",
+  )
+
+  for key, value in overrides.items():
+    setattr(config, key, value)
+
+  return config
+
+
+def test_apply_upstream_url_rewrite_skips_for_local_test_workflow(monkeypatch):
+  called = []
+  monkeypatch.setattr(rewrite_module.Settings, "instance", lambda: _settings_with_project_id())
+  monkeypatch.setattr(rewrite_module, "set_rewrite_rule", lambda *args, **kwargs: called.append((args, kwargs)))
+
+  service_config = _service_config(local=True)
+  apply_upstream_url_rewrite(service_config, WORKFLOW_TEST_TYPE)
+
+  assert called == []
+
+
+def test_apply_upstream_url_rewrite_applies_for_local_non_test_workflow(monkeypatch):
+  called = []
+  monkeypatch.setattr(rewrite_module.Settings, "instance", lambda: _settings_with_project_id())
+  monkeypatch.setattr(rewrite_module, "set_rewrite_rule", lambda *args, **kwargs: called.append((args, kwargs)))
+
+  service_config = _service_config(local=True)
+  apply_upstream_url_rewrite(service_config, WORKFLOW_RECORD_TYPE)
+
+  assert len(called) == 1

--- a/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
@@ -1,14 +1,18 @@
 from types import SimpleNamespace
 
 from stoobly_agent.app.cli.scaffold.rewrite import apply_upstream_url_rewrite
+from stoobly_agent.config.constants import method, mode
+from stoobly_agent.lib.api.keys.project_key import ProjectKey
 import stoobly_agent.app.cli.scaffold.rewrite as rewrite_module
 
+organization_id = "org-id"
+project_id = "project-id"
 
-def _settings_with_project_id(project_id: str = "project-id"):
+def _settings_with_project_id(project_id: str = project_id):
   return SimpleNamespace(
     proxy=SimpleNamespace(
       intercept=SimpleNamespace(
-        project_key=f"org/{project_id}"
+        project_key=ProjectKey.encode(project_id, organization_id=organization_id)
       )
     )
   )
@@ -52,6 +56,16 @@ def test_apply_upstream_url_rewrite_applies_when_upstream_differs(monkeypatch):
   apply_upstream_url_rewrite(service_config)
 
   assert len(called) == 1
+  args, kwargs = called[0]
+  assert args == (project_id,)
+  assert kwargs == {
+    "pattern": "https://api.example.test/?.*?",
+    "method": [method.GET, method.PATCH, method.POST, method.PUT, method.DELETE, method.OPTIONS],
+    "mode": [mode.REPLAY],
+    "hostname": "upstream.example.test",
+    "port": 8443,
+    "scheme": "https",
+  }
 
 
 def test_apply_upstream_url_rewrite_skips_when_upstream_matches_service(monkeypatch):

--- a/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/rewrite_test.py
@@ -1,6 +1,5 @@
 from types import SimpleNamespace
 
-from stoobly_agent.app.cli.scaffold.constants import WORKFLOW_RECORD_TYPE, WORKFLOW_TEST_TYPE
 from stoobly_agent.app.cli.scaffold.rewrite import apply_upstream_url_rewrite
 import stoobly_agent.app.cli.scaffold.rewrite as rewrite_module
 
@@ -33,23 +32,38 @@ def _service_config(**overrides):
   return config
 
 
-def test_apply_upstream_url_rewrite_skips_for_local_test_workflow(monkeypatch):
+def test_apply_upstream_url_rewrite_skips_when_service_url_missing(monkeypatch):
   called = []
   monkeypatch.setattr(rewrite_module.Settings, "instance", lambda: _settings_with_project_id())
   monkeypatch.setattr(rewrite_module, "set_rewrite_rule", lambda *args, **kwargs: called.append((args, kwargs)))
 
-  service_config = _service_config(local=True)
-  apply_upstream_url_rewrite(service_config, WORKFLOW_TEST_TYPE)
+  service_config = _service_config(url=None)
+  apply_upstream_url_rewrite(service_config)
 
   assert called == []
 
 
-def test_apply_upstream_url_rewrite_applies_for_local_non_test_workflow(monkeypatch):
+def test_apply_upstream_url_rewrite_applies_when_upstream_differs(monkeypatch):
   called = []
   monkeypatch.setattr(rewrite_module.Settings, "instance", lambda: _settings_with_project_id())
   monkeypatch.setattr(rewrite_module, "set_rewrite_rule", lambda *args, **kwargs: called.append((args, kwargs)))
 
-  service_config = _service_config(local=True)
-  apply_upstream_url_rewrite(service_config, WORKFLOW_RECORD_TYPE)
+  service_config = _service_config()
+  apply_upstream_url_rewrite(service_config)
 
   assert len(called) == 1
+
+
+def test_apply_upstream_url_rewrite_skips_when_upstream_matches_service(monkeypatch):
+  called = []
+  monkeypatch.setattr(rewrite_module.Settings, "instance", lambda: _settings_with_project_id())
+  monkeypatch.setattr(rewrite_module, "set_rewrite_rule", lambda *args, **kwargs: called.append((args, kwargs)))
+
+  service_config = _service_config(
+    upstream_hostname="api.example.test",
+    upstream_port=443,
+    upstream_scheme="https",
+  )
+  apply_upstream_url_rewrite(service_config)
+
+  assert called == []


### PR DESCRIPTION
## Branch Risk Review (`651-command-scaffold-workflow-rewrite` vs `master`)

### Key Findings (highest risk first)

- **Medium risk: rewrite behavior moved from implicit to explicit**
  - Rewrite-rule creation was removed from the normal workflow run path in `scaffold/run.py`.
  - It now happens through the new command `scaffold workflow rewrite` in `scaffold_cli.py`.
  - This is a functional change whenever a service’s upstream (`UPSTREAM_*`) differs from its public URL.

- **Low risk: Docker forward-proxy `extra_hosts` added only for local services**
  - `gateway_base.py` now adds `host.docker.internal:host-gateway` **only** when at least one service is `local`.
  - If no service is local, this branch does nothing.

- **Low risk: `LocalDecorator` scoping fix**
  - `LocalDecorator` is now only applied under reverse proxy mode (indentation fix in `decorators_factory.py`).
  - This does not affect non-local service setups.

- **Low risk: local port validation relaxed**
  - `service_config.py` no longer rejects `port == upstream_port` for local services.
  - Irrelevant if no services are marked local.

---

### Direct Answer: “If no service is set as local, are there any functional changes?”

- **For local-service-specific paths:** effectively **no functional change**.
  - No `extra_hosts` injection.
  - No local-decorator behavior changes.

- **But there is still one functional change unrelated to `local`:**
  - Rewrite-rule sync is no longer implicitly done during workflow command iteration.
  - It now depends on running:
    - `stoobly-agent scaffold workflow rewrite <workflow_name>`

So if your services are all non-local **and** upstream matches service URL, behavior is effectively unchanged.  
If any non-local service uses different upstream host/port/scheme, behavior can differ unless rewrite sync is run.

---

### Overall Risk

- **Overall:** `Low -> Medium`
- **Main risk driver:** rewrite-flow semantics/timing change, not local-service behavior.