### PR TITLE
657 default test workflow to test intercept mode

### DIFF
--- a/stoobly_agent/app/api/configs_controller.py
+++ b/stoobly_agent/app/api/configs_controller.py
@@ -90,7 +90,7 @@ class ConfigsController:
 
         remote_project_id = self.__remote_project_id(settings)
 
-        modes = [mode.RECORD, mode.MOCK, mode.TEST, mode.REPLAY] if not context.params.get('agent') else [mode.RECORD, mode.MOCK, mode.REPLAY]
+        modes = [mode.RECORD, mode.MOCK, mode.TEST, mode.REPLAY]
 
         context.render(
             json = {

--- a/stoobly_agent/app/cli/scaffold/templates/build/services/build/test/.init
+++ b/stoobly_agent/app/cli/scaffold/templates/build/services/build/test/.init
@@ -14,6 +14,7 @@ fi
 
 echo "Configuring intercept..."
 stoobly-agent intercept configure --mode mock --policy all
+stoobly-agent intercept configure --mode test --policy none
 stoobly-agent intercept enable
 
 if [ "$APP_PROXY_MODE" = "forward" ]; then

--- a/stoobly_agent/app/proxy/handle_mock_service.py
+++ b/stoobly_agent/app/proxy/handle_mock_service.py
@@ -28,6 +28,7 @@ class MockOptions(TypedDict):
     ignored_components: list 
     infer: bool
     no_rewrite: bool
+    policy_override: str
     success: Callable
 
 def handle_mock_failure(context: MockContext) -> Union[None, 'MitmproxyResponse']:
@@ -76,20 +77,23 @@ def handle_request_mock_generic(context: MockContext, **options: MockOptions):
     handle_failure = options['failure'] if 'failure' in options and callable(options['failure']) else None
     handle_success = options['success'] if 'success' in options and callable(options['success']) else None
     intercept_settings = context.intercept_settings
+    policy_override = options['policy_override'] if 'policy_override' in options else None
     request: MitmproxyRequest = context.flow.request
     res = None
 
     # If policy override is set, use it, otherwise use the intercept mode policy
-    policy = get_intercept_mode_policy(request, intercept_settings, mode.MOCK)
+    policy = policy_override or get_intercept_mode_policy(request, intercept_settings, mode.MOCK)
     if policy == mock_policy.NONE:
-        return
-
-    if policy not in [mock_policy.ALL, mock_policy.FOUND]:
         if handle_error:
             res = handle_error(context)
 
             if res:
                 return pass_on(context.flow, res)
+        return
+
+    if policy not in [mock_policy.ALL, mock_policy.FOUND]:
+        if handle_error:
+            res = handle_error(context)
 
         return bad_request(
             context.flow,

--- a/stoobly_agent/app/proxy/handle_mock_service.py
+++ b/stoobly_agent/app/proxy/handle_mock_service.py
@@ -1,6 +1,4 @@
-import os
 import pdb
-import time
 
 from typing import TYPE_CHECKING, Callable, TypedDict, Union
 
@@ -11,7 +9,7 @@ if TYPE_CHECKING:
 from stoobly_agent.app.models.request_model import RequestModel
 from stoobly_agent.app.proxy.mitmproxy.request_facade import MitmproxyRequestFacade
 from stoobly_agent.app.proxy.utils.rewrite_rules_to_ignored_components_service import rewrite_rules_to_ignored_components
-from stoobly_agent.config.constants import custom_headers, env_vars, lifecycle_hooks, mock_policy, mode, request_origin
+from stoobly_agent.config.constants import custom_headers, lifecycle_hooks, mock_policy, mode, request_origin
 from stoobly_agent.lib.logger import bcolors, Logger
 from stoobly_agent.lib.intercepted_requests.logger import InterceptedRequestsLogger
 from .constants import custom_response_codes

--- a/stoobly_agent/app/proxy/handle_mock_service.py
+++ b/stoobly_agent/app/proxy/handle_mock_service.py
@@ -2,6 +2,9 @@ import pdb
 
 from typing import TYPE_CHECKING, Callable, TypedDict, Union
 
+from stoobly_agent.app.proxy.handle_replay_service import handle_request_replay, handle_response_replay
+from stoobly_agent.app.proxy.replay.context import ReplayContext
+
 if TYPE_CHECKING:
     from requests import Response
     from mitmproxy.http import Request as MitmproxyRequest, Response as MitmproxyResponse
@@ -167,7 +170,12 @@ def eval_request_with_retry(context: MockContext, eval_request, **options: MockO
 
     return res
 
+###
+# 
+# 1. BEFORE_REPLAY gets triggered
+#
 def handle_request_mock(context: MockContext):
+    handle_request_replay(ReplayContext(context.flow, context.intercept_settings))
     handle_request_mock_generic(
         context,
         failure=handle_mock_failure,
@@ -177,10 +185,12 @@ def handle_request_mock(context: MockContext):
 ###
 #
 # Occurs if mock is found
-# 1. Rewrites mock response
-# 2. AFTER_MOCK gets triggered
+# 1. AFTER_RESPONSE gets triggered
+# 3. Rewrites mock response
+# 3. AFTER_MOCK gets triggered
 #
 def handle_response_mock(context: MockContext):
+    handle_response_replay(ReplayContext(context.flow, context.intercept_settings))
     __rewrite_response(context)
     __mock_hook(lifecycle_hooks.AFTER_MOCK, context)
 

--- a/stoobly_agent/app/proxy/handle_mock_service.py
+++ b/stoobly_agent/app/proxy/handle_mock_service.py
@@ -30,7 +30,6 @@ class MockOptions(TypedDict):
     ignored_components: list 
     infer: bool
     no_rewrite: bool
-    policy_override: str
     success: Callable
 
 def handle_mock_failure(context: MockContext) -> Union[None, 'MitmproxyResponse']:
@@ -79,23 +78,20 @@ def handle_request_mock_generic(context: MockContext, **options: MockOptions):
     handle_failure = options['failure'] if 'failure' in options and callable(options['failure']) else None
     handle_success = options['success'] if 'success' in options and callable(options['success']) else None
     intercept_settings = context.intercept_settings
-    policy_override = options['policy_override'] if 'policy_override' in options else None
     request: MitmproxyRequest = context.flow.request
     res = None
 
     # If policy override is set, use it, otherwise use the intercept mode policy
-    policy = policy_override or get_intercept_mode_policy(request, intercept_settings, mode.MOCK)
+    policy = get_intercept_mode_policy(request, intercept_settings, mode.MOCK)
     if policy == mock_policy.NONE:
-        if handle_error:
-            res = handle_error(context)
-
-            if res:
-                return pass_on(context.flow, res)
         return
 
     if policy not in [mock_policy.ALL, mock_policy.FOUND]:
         if handle_error:
             res = handle_error(context)
+
+            if res:
+                return pass_on(context.flow, res)
 
         return bad_request(
             context.flow,

--- a/stoobly_agent/app/proxy/handle_test_service.py
+++ b/stoobly_agent/app/proxy/handle_test_service.py
@@ -109,7 +109,6 @@ def handle_response_test(context: ReplayContext) -> None:
             MockContext(mock_flow, context.intercept_settings),
             error=handle_mock_error,
             failure=handle_mock_failure,
-            policy_override=mock_policy.ALL, # Because we are testing, we need mocking to determine expected response
             success=handle_mock_success
             #infer=intercept_settings.test_strategy == test_strategy.FUZZY, # For fuzzy testing we can use an inferred response
         )

--- a/stoobly_agent/app/proxy/handle_test_service.py
+++ b/stoobly_agent/app/proxy/handle_test_service.py
@@ -3,10 +3,11 @@ import pdb
 from typing import TYPE_CHECKING, Union
 
 from stoobly_agent.app.cli.helpers.feature_flags import is_local
+from stoobly_agent.app.proxy.utils.allowed_request_service import get_intercept_mode_policy
 from stoobly_agent.app.settings import Settings
 
 if TYPE_CHECKING:
-    from mitmproxy.http import HTTPFlow as MitmproxyHTTPFlow
+    from mitmproxy.http import HTTPFlow as MitmproxyHTTPFlow, Request as MitmproxyRequest
 
 from stoobly_agent.app.proxy.context import InterceptContext
 from stoobly_agent.app.proxy.intercept_settings import InterceptSettings
@@ -15,7 +16,7 @@ from stoobly_agent.app.proxy.replay.body_parser_service import encode_response
 from stoobly_agent.app.proxy.replay.context import ReplayContext
 from stoobly_agent.app.proxy.utils.request_handler import build_response
 from stoobly_agent.app.proxy.utils.response_handler import bad_request, disable_transfer_encoding
-from stoobly_agent.config.constants import custom_headers, lifecycle_hooks, mock_policy, request_origin, test_policy
+from stoobly_agent.config.constants import custom_headers, lifecycle_hooks, mock_policy, mode, request_origin, test_policy
 from stoobly_agent.lib.logger import Logger, bcolors
 
 from .handle_mock_service import (
@@ -37,7 +38,11 @@ LOG_ID = 'Test'
 
 ###
 #
-# 1. BEFORE_REPLAY gets triggered
+# Lifecycle hook order for standard test_policy=found path:
+#
+# 1.  BEFORE_REQUEST gets triggered
+# 2.  BEFORE_REPLAY gets triggered
+# 3.  AFTER_REPLAY gets triggered
 #
 def handle_request_test(context: ReplayContext) -> None:
     if context.intercept_settings.policy == test_policy.FOUND:
@@ -52,10 +57,6 @@ def handle_request_test(context: ReplayContext) -> None:
 
 ###
 #
-# Lifecycle hook order for standard test_policy=found path:
-# 1.  BEFORE_REQUEST gets triggered
-# 2.  BEFORE_REPLAY gets triggered
-# 3.  AFTER_REPLAY gets triggered
 # 4.  BEFORE_MOCK gets triggered
 # 5.  AFTER_MOCK gets triggered
 # 6.  BEFORE_TEST gets triggered
@@ -74,17 +75,29 @@ def handle_response_test(context: ReplayContext) -> None:
 
     flow: 'MitmproxyHTTPFlow' = context.flow
     intercept_settings: InterceptSettings = context.intercept_settings
+    request: MitmproxyRequest = context.flow.request
+
+    policy = get_intercept_mode_policy(request, intercept_settings, mode.TEST)
 
     # Mock policy is used for response handling
     # Exception is request_origin is CLI, then a custom response is returned for the CLI to process
 
-    if intercept_settings.test_policy == test_policy.FOUND:
+    if policy == test_policy.NONE:
+        handle_response_mock(MockContext(flow, intercept_settings))
+    elif policy == test_policy.FOUND:
         disable_transfer_encoding(flow.response)
         handle_response_replay(context)
 
-        # If mock policy is NONE, we return live request response
-        # To achieve this, copy the flow to prevent modifications from persisting
-        mock_flow = flow.copy() if intercept_settings.mock_policy == mock_policy.NONE else flow
+        if intercept_settings.mock_policy == mock_policy.NONE:
+            # If mock policy is NONE, we return live request response
+            # To achieve this, copy the flow to prevent modifications from persisting
+            mock_flow = flow.copy()
+
+            # Because we are testing, we need mocking to determine expected response
+            policy_override = mock_policy.ALL
+        else:
+            mock_flow = flow
+            policy_override = intercept_settings.mock_policy
 
         test_context: TestContext = None
         def build_test_context(mock_context: MockContext):
@@ -109,8 +122,8 @@ def handle_response_test(context: ReplayContext) -> None:
             MockContext(mock_flow, context.intercept_settings),
             error=handle_mock_error,
             failure=handle_mock_failure,
-            policy_override=mock_policy.ALL, # Because we are testing, we need mocking to determine expected response
-            success=handle_mock_success
+            success=handle_mock_success,
+            policy_override=policy_override,
             #infer=intercept_settings.test_strategy == test_strategy.FUZZY, # For fuzzy testing we can use an inferred response
         )
 
@@ -122,8 +135,6 @@ def handle_response_test(context: ReplayContext) -> None:
             # Apply test ID from flow.copy() to the original flow that will returned to the client
             if test_context.test_id:
                 __decorate_test_id(flow, test_context.test_id)
-    else:
-        handle_response_mock(MockContext(flow, intercept_settings))
 
 def __decorate_test_id(flow: 'MitmproxyHTTPFlow', test_id: Union[str, None]):
     if test_id:

--- a/stoobly_agent/app/proxy/handle_test_service.py
+++ b/stoobly_agent/app/proxy/handle_test_service.py
@@ -109,6 +109,7 @@ def handle_response_test(context: ReplayContext) -> None:
             MockContext(mock_flow, context.intercept_settings),
             error=handle_mock_error,
             failure=handle_mock_failure,
+            policy_override=mock_policy.ALL, # Because we are testing, we need mocking to determine expected response
             success=handle_mock_success
             #infer=intercept_settings.test_strategy == test_strategy.FUZZY, # For fuzzy testing we can use an inferred response
         )

--- a/stoobly_agent/app/proxy/handle_test_service.py
+++ b/stoobly_agent/app/proxy/handle_test_service.py
@@ -16,7 +16,7 @@ from stoobly_agent.app.proxy.replay.body_parser_service import encode_response
 from stoobly_agent.app.proxy.replay.context import ReplayContext
 from stoobly_agent.app.proxy.utils.request_handler import build_response
 from stoobly_agent.app.proxy.utils.response_handler import bad_request, disable_transfer_encoding
-from stoobly_agent.config.constants import custom_headers, lifecycle_hooks, mock_policy, mode, request_origin, test_policy
+from stoobly_agent.config.constants import custom_headers, lifecycle_hooks, mock_policy, mode, record_policy, request_origin, test_policy
 from stoobly_agent.lib.logger import Logger, bcolors
 
 from .handle_mock_service import (
@@ -77,29 +77,24 @@ def handle_response_test(context: ReplayContext) -> None:
     intercept_settings: InterceptSettings = context.intercept_settings
     request: MitmproxyRequest = context.flow.request
 
-    policy = get_intercept_mode_policy(request, intercept_settings, mode.TEST)
+    # If test policy is NONE, then use mock flow
+    _test_policy = get_intercept_mode_policy(request, intercept_settings, mode.TEST)
+    if _test_policy == test_policy.NONE:
+        handle_response_mock(MockContext(flow, intercept_settings))
+        return
+
+    # Else use test flow
+    disable_transfer_encoding(flow.response)
+    handle_response_replay(context)
 
     # Mock policy is used for response handling
     # Exception is request_origin is CLI, then a custom response is returned for the CLI to process
+    _mock_policy = get_intercept_mode_policy(request, intercept_settings, mode.MOCK)
 
-    if policy == test_policy.NONE:
-        handle_response_mock(MockContext(flow, intercept_settings))
-    elif policy == test_policy.FOUND:
-        disable_transfer_encoding(flow.response)
-        handle_response_replay(context)
+    mock_flow = flow.copy()
+    test_context: TestContext = None
 
-        if intercept_settings.mock_policy == mock_policy.NONE:
-            # If mock policy is NONE, we return live request response
-            # To achieve this, copy the flow to prevent modifications from persisting
-            mock_flow = flow.copy()
-
-            # Because we are testing, we need mocking to determine expected response
-            policy_override = mock_policy.ALL
-        else:
-            mock_flow = flow
-            policy_override = intercept_settings.mock_policy
-
-        test_context: TestContext = None
+    if _test_policy == test_policy.FOUND:
         def build_test_context(mock_context: MockContext):
             nonlocal test_context  # Bind to outer scope variable so modifications are visible after callback execution
             # Deep copy flow to prevent modifications from persisting
@@ -118,23 +113,37 @@ def handle_response_test(context: ReplayContext) -> None:
             handle_response_mock(mock_context)
             return __handle_mock_success(build_test_context(mock_context))
 
+        if _mock_policy == mock_policy.NONE:
+            # Because we are testing, we can't use mock policy NONE
+            # we need mocking to determine expected response
+            mock_policy_override = mock_policy.ALL
+        else:
+            mock_policy_override = _mock_policy
+
         handle_request_mock_generic(
             MockContext(mock_flow, context.intercept_settings),
             error=handle_mock_error,
             failure=handle_mock_failure,
             success=handle_mock_success,
-            policy_override=policy_override,
+            policy_override=mock_policy_override,
             #infer=intercept_settings.test_strategy == test_strategy.FUZZY, # For fuzzy testing we can use an inferred response
         )
 
-        # If test context was built, and it has test results, override response with test results
-        if test_context:
-            if test_context.test_results:
-                __override_response(flow, test_context.test_results.serialize())
+    # If test context was built, and it has test results, override response with test results
+    if test_context:
+        if test_context.test_results:
+            __override_response(flow, test_context.test_results.serialize())
 
-            # Apply test ID from flow.copy() to the original flow that will returned to the client
-            if test_context.test_id:
-                __decorate_test_id(flow, test_context.test_id)
+        # Apply test ID from flow.copy() to the original flow that will returned to the client
+        if test_context.test_id:
+            __decorate_test_id(flow, test_context.test_id)
+
+    # If response was not overridden
+    if not test_context or not test_context.test_results:
+        # If mock policy is not NONE, return mock response
+        # else we return live request response
+        if _mock_policy != mock_policy.NONE:
+            flow.response = mock_flow.response
 
 def __decorate_test_id(flow: 'MitmproxyHTTPFlow', test_id: Union[str, None]):
     if test_id:
@@ -201,7 +210,7 @@ def __handle_mock_success(test_context: TestContext) -> None:
 
             res = __record_handler(test_context, upload_test_data)
 
-            if is_cli:
+            if res and is_cli:
                 # This CLI path implies save was on; record success as test id, or clear save intent after a failed upload.
                 if res.ok:
                     response = res.json()
@@ -242,23 +251,32 @@ def __override_response(flow: 'MitmproxyHTTPFlow', content: bytes):
     flow.response.status_code = 200
 
 def __record_handler(context: TestContext, upload_test_data):
-    flow = context.flow.copy() # Deep copy flow to prevent response modifications from persisting
+    flow = context.flow
     intercept_settings = context.intercept_settings
-    record_context = RecordContext(flow, intercept_settings)
+    request: MitmproxyRequest = flow.request
 
-    # Since we are "uploading" the request, use record_write_rules
-    rewrite_request_response(record_context.flow, intercept_settings.record_rewrite_rules)
-    __test_hook(lifecycle_hooks.BEFORE_RECORD, record_context)
+    _record_policy = get_intercept_mode_policy(request, intercept_settings, mode.RECORD)
+    if _record_policy == record_policy.NONE:
+        return None
+    else:
+        # Deep copy flow to prevent response modifications from persisting
+        record_context = RecordContext(flow.copy(), intercept_settings)
 
-    # Commit test to API
-    upload_test = inject_upload_test(None, intercept_settings)
-    res = upload_test(
-        record_context.flow, **upload_test_data
-    )
+        # TODO: apply other record policies
 
-    __test_hook(lifecycle_hooks.AFTER_RECORD, record_context)
+        # Since we are "uploading" the request, use record_write_rules
+        rewrite_request_response(record_context.flow, intercept_settings.record_rewrite_rules)
+        __test_hook(lifecycle_hooks.BEFORE_RECORD, record_context)
 
-    return res
+        # Commit test to API
+        upload_test = inject_upload_test(None, intercept_settings)
+        res = upload_test(
+            record_context.flow, **upload_test_data
+        )
+
+        __test_hook(lifecycle_hooks.AFTER_RECORD, record_context)
+
+        return res
 
 def __rewrite_request(context: ReplayContext):
     """

--- a/stoobly_agent/app/proxy/intercept_settings.py
+++ b/stoobly_agent/app/proxy/intercept_settings.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mitmproxy.http import Request as MitmproxyRequest
-    from .mock.types import LifecycleHooksPath
 
 from stoobly_agent.app.cli.helpers.feature_flags import is_remote
 from stoobly_agent.app.settings.constants import firewall_action, intercept_mode
@@ -32,8 +31,7 @@ class InterceptSettings:
   def __init__(self, settings: Settings, request: 'MitmproxyRequest' = None, cache: Optional[Cache] = None, scenario_model: Optional[ScenarioModel] = None):
     self.__settings = settings
     self.__request = request
-    # Lazy import for runtime usage
-    from mitmproxy.http import Request as MitmproxyRequest
+
     self.__headers: 'MitmproxyRequest.headers' = request.headers if request else None
     self.__for_response = False
     self.__cache = cache

--- a/stoobly_agent/app/proxy/test/context.py
+++ b/stoobly_agent/app/proxy/test/context.py
@@ -9,7 +9,7 @@ from stoobly_agent.app.cli.helpers.context import ReplayContext
 from stoobly_agent.app.proxy.mitmproxy.request_facade import MitmproxyRequestFacade
 from stoobly_agent.app.proxy.mock.context import MockContext
 from stoobly_agent.app.proxy.replay.alias_resolver import AliasResolver
-from stoobly_agent.app.proxy.replay.body_parser_service import is_traversable
+from stoobly_agent.app.proxy.replay.body_parser_service import encode_response, is_traversable
 from stoobly_agent.app.proxy.replay.rewrite_params_service import build_id_to_alias_map, rewrite_params
 from stoobly_agent.app.proxy.test.helpers.endpoint_facade import EndpointFacade
 from stoobly_agent.app.proxy.test.helpers.mitmproxy_response_adapter import MitmproxyResponseAdapter
@@ -33,8 +33,7 @@ class TestContext(TestContextABC):
     self.__replay_context = replay_context
 
     mock_response = self.__mock_context.response
-    if mock_response:
-      self.__expected_response = RequestsResponseAdapter(mock_response).adapt()
+    self.__expected_response = RequestsResponseAdapter(mock_response).adapt()
 
     upstream_response = self.__flow.response
     self.__response = MitmproxyResponseAdapter(upstream_response).adapt()
@@ -85,7 +84,7 @@ class TestContext(TestContextABC):
     return self.__mock_context.response.headers.get(custom_headers.RESPONSE_LATENCY)
 
   @property
-  def expected_response(self) -> Union[TestContextResponse, None]:
+  def expected_response(self):
     return self.__expected_response
 
   @property

--- a/stoobly_agent/app/proxy/test/context.py
+++ b/stoobly_agent/app/proxy/test/context.py
@@ -9,7 +9,7 @@ from stoobly_agent.app.cli.helpers.context import ReplayContext
 from stoobly_agent.app.proxy.mitmproxy.request_facade import MitmproxyRequestFacade
 from stoobly_agent.app.proxy.mock.context import MockContext
 from stoobly_agent.app.proxy.replay.alias_resolver import AliasResolver
-from stoobly_agent.app.proxy.replay.body_parser_service import encode_response, is_traversable
+from stoobly_agent.app.proxy.replay.body_parser_service import is_traversable
 from stoobly_agent.app.proxy.replay.rewrite_params_service import build_id_to_alias_map, rewrite_params
 from stoobly_agent.app.proxy.test.helpers.endpoint_facade import EndpointFacade
 from stoobly_agent.app.proxy.test.helpers.mitmproxy_response_adapter import MitmproxyResponseAdapter
@@ -33,7 +33,8 @@ class TestContext(TestContextABC):
     self.__replay_context = replay_context
 
     mock_response = self.__mock_context.response
-    self.__expected_response = RequestsResponseAdapter(mock_response).adapt()
+    if mock_response:
+      self.__expected_response = RequestsResponseAdapter(mock_response).adapt()
 
     upstream_response = self.__flow.response
     self.__response = MitmproxyResponseAdapter(upstream_response).adapt()
@@ -84,7 +85,7 @@ class TestContext(TestContextABC):
     return self.__mock_context.response.headers.get(custom_headers.RESPONSE_LATENCY)
 
   @property
-  def expected_response(self):
+  def expected_response(self) -> Union[TestContextResponse, None]:
     return self.__expected_response
 
   @property

--- a/stoobly_agent/app/proxy/utils/response_handler.py
+++ b/stoobly_agent/app/proxy/utils/response_handler.py
@@ -54,6 +54,7 @@ def enable_cors(flow: 'MitmproxyHTTPFlow'):
     )
 
 # Without deleting this header, causes parsing issues when reading response
+# Note: this should only be applied to live responses and not mocked responses
 def disable_transfer_encoding(response: 'MitmproxyResponse') -> None:
     header_name = 'Transfer-Encoding'
     header_values = response.headers.get_all(header_name)

--- a/stoobly_agent/test/app/api/configs_controller_test.py
+++ b/stoobly_agent/test/app/api/configs_controller_test.py
@@ -131,7 +131,7 @@ class TestConfigsController:
             _, kwargs = mock_context.render.call_args
             response_data = kwargs['json']
 
-            expected_modes = [mode.RECORD, mode.MOCK, mode.REPLAY]
+            expected_modes = [mode.RECORD, mode.MOCK, mode.TEST, mode.REPLAY]
             assert response_data['modes'] == expected_modes
 
         def test_summary_without_agent_param(self, controller, mock_context):

--- a/stoobly_agent/test/app/cli/request/request_test_test.py
+++ b/stoobly_agent/test/app/cli/request/request_test_test.py
@@ -30,7 +30,7 @@ class TestReplay():
 
         def test_it_matches(self, runner, recorded_request: Request):
             replay_result = runner.invoke(request, ['test', '--strategy', test_strategy.DIFF, recorded_request.key()])
-            assert replay_result.exit_code == 0
+            assert replay_result.exit_code == 0, replay_result.stdout
 
     class TestWhenContractStrategy():
 

--- a/stoobly_agent/test/app/cli/scaffold/local/workflow_test.py
+++ b/stoobly_agent/test/app/cli/scaffold/local/workflow_test.py
@@ -390,9 +390,9 @@ class TestLocalScaffoldE2e():
       res = requests.get('http://' + hostname, proxies={'http': proxy_url, 'https': proxy_url}, verify=False)
       assert res.status_code == 499, "HTTP request with HTTP_PROXY and HTTPS_PROXY set to the local service should succeed"
 
-    def test_intercept_mode_mock(self, settings: Settings):
-      # Check starts with Mock
-      assert settings.proxy.intercept.mode == mode.MOCK
+    def test_intercept_mode_test(self, settings: Settings):
+      # Check starts with Test
+      assert settings.proxy.intercept.mode == mode.TEST
 
     def test_intercept_mode_active(self, settings: Settings):
       assert settings.proxy.intercept.active

--- a/stoobly_agent/test/app/proxy/handle_test_service_test.py
+++ b/stoobly_agent/test/app/proxy/handle_test_service_test.py
@@ -35,7 +35,13 @@ class TestHandleTestService:
 
     @patch('stoobly_agent.app.proxy.handle_test_service.handle_response_replay')
     @patch('stoobly_agent.app.proxy.handle_test_service.handle_response_mock')
-    def test_handle_response_test_policy_none_uses_mock_path(self, mock_handle_response_mock, mock_handle_response_replay):
+    @patch('stoobly_agent.app.proxy.handle_test_service.get_intercept_mode_policy')
+    def test_handle_response_test_policy_none_uses_mock_path(
+        self,
+        mock_get_intercept_mode_policy,
+        mock_handle_response_mock,
+        mock_handle_response_replay,
+    ):
         flow = MagicMock()
         flow.response = MagicMock()
 
@@ -46,32 +52,28 @@ class TestHandleTestService:
         context.flow = flow
         context.intercept_settings = intercept_settings
 
+        mock_get_intercept_mode_policy.return_value = test_policy.NONE
         handle_response_test(context)
 
         mock_handle_response_mock.assert_called_once()
         mock_handle_response_replay.assert_not_called()
 
-    @pytest.mark.parametrize(
-        'mock_policy_value, expect_copy',
-        [
-            (mock_policy.NONE, True),
-            (mock_policy.FOUND, False),
-            (mock_policy.ALL, False),
-        ],
-    )
+    @pytest.mark.parametrize('mock_policy_value', [mock_policy.NONE, mock_policy.FOUND, mock_policy.ALL])
     @patch('stoobly_agent.app.proxy.handle_test_service.disable_transfer_encoding')
     @patch('stoobly_agent.app.proxy.handle_test_service.handle_response_replay')
     @patch('stoobly_agent.app.proxy.handle_test_service.handle_request_mock_generic')
+    @patch('stoobly_agent.app.proxy.handle_test_service.get_intercept_mode_policy')
     def test_handle_response_test_policy_found_forces_mock_all(
         self,
+        mock_get_intercept_mode_policy,
         mock_handle_request_mock_generic,
         mock_handle_response_replay,
         mock_disable_transfer_encoding,
         mock_policy_value,
-        expect_copy,
     ):
         flow = MagicMock()
         flow.response = MagicMock()
+        original_response = flow.response
         flow.request = MagicMock()
         flow.request.headers = {}
 
@@ -81,8 +83,7 @@ class TestHandleTestService:
         flow.copy.return_value = flow_copy
 
         intercept_settings = MagicMock()
-        intercept_settings.test_policy = test_policy.FOUND
-        intercept_settings.mock_policy = mock_policy_value
+        mock_get_intercept_mode_policy.side_effect = [test_policy.FOUND, mock_policy_value]
 
         context = MagicMock()
         context.flow = flow
@@ -90,10 +91,9 @@ class TestHandleTestService:
 
         handle_response_test(context)
 
-        mock_disable_transfer_encoding.assert_called_once_with(flow.response)
+        mock_disable_transfer_encoding.assert_called_once_with(original_response)
         mock_handle_response_replay.assert_called_once_with(context)
         mock_handle_request_mock_generic.assert_called_once()
 
         passed_mock_context = mock_handle_request_mock_generic.call_args.args[0]
-        expected_flow = flow_copy if expect_copy else flow
-        assert passed_mock_context.flow is expected_flow
+        assert passed_mock_context.flow is flow_copy

--- a/stoobly_agent/test/app/proxy/handle_test_service_test.py
+++ b/stoobly_agent/test/app/proxy/handle_test_service_test.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from stoobly_agent.app.proxy.handle_test_service import handle_request_test, handle_response_test
-from stoobly_agent.config.constants import custom_headers, mock_policy, test_policy
+from stoobly_agent.config.constants import mock_policy, test_policy
 
 
 class TestHandleTestService:

--- a/stoobly_agent/test/cli/lifecycle_hooks_test.py
+++ b/stoobly_agent/test/cli/lifecycle_hooks_test.py
@@ -71,7 +71,7 @@ class TestLifecycleHooks():
     assert record_result.stdout.strip() == "\n".join(expected_stdout)
 
   def test_calls_mock_hooks(self, mock_result):
-    expected_stdout = ['before_request', 'before_mock', 'after_mock', 'before_response']
+    expected_stdout = ['before_request', 'before_replay', 'before_mock', 'after_replay', 'after_mock', 'before_response']
     assert mock_result.stdout.strip() == "\n".join(expected_stdout)
 
   def test_calls_replay_hooks(self, replay_result):
@@ -81,12 +81,49 @@ class TestLifecycleHooks():
     assert lifecycle_hooks_output.strip() == "\n".join(expected_stdout)
 
   def test_calls_test_hooks(self, test_result):
+    # In a test_policy=found flow, 
+    # before_replay and after_replay are called twice for mock flow and test flow respectively
      expected_stdout = [
-       'before_request', 'before_replay', 'after_replay', 'before_mock', 'after_mock', 'before_test', 'after_test', 'before_response'
+       'before_request', 'before_replay', 'after_replay', 'before_mock', 'after_replay', 'after_mock', 'before_test', 'after_test', 'before_response'
      ]
      stdout = test_result.stdout
      lifecycle_hooks_output = stdout.split('{')[0]
      assert lifecycle_hooks_output.strip() == "\n".join(expected_stdout)
+
+  class TestWithTestPolicyNone():
+    @pytest.fixture(scope='class', autouse=True)
+    def settings(self):
+      return reset()
+
+    @pytest.fixture(scope='class')
+    def lifecycle_hooks_path(self):
+      return str(Path(__file__).parent.parent / 'mock_data' / 'lifecycle_hooks.py')
+
+    @pytest.fixture(scope='class')
+    def test_result(self, runner: CliRunner, lifecycle_hooks_path: str):
+      settings = Settings.instance()
+      project_key = ProjectKey(settings.proxy.intercept.project_key)
+      data_rule = settings.proxy.data.data_rules(project_key.id)
+      data_rule.record_policy = record_policy.ALL
+      data_rule.test_policy = test_policy.NONE
+      settings.commit()
+
+      record_result = runner.invoke(record, [DETERMINISTIC_GET_REQUEST_URL])
+      assert record_result.exit_code == 0
+      recorded_request = Request.last()
+
+      test_result = runner.invoke(request, [
+        'test', '--format', 'json', '--lifecycle-hooks-path', lifecycle_hooks_path, recorded_request.key()
+      ])
+      return test_result
+
+    def test_calls_test_hooks(self, test_result):
+      expected_stdout = [
+        'before_request', 'before_replay', 'before_mock', 'after_replay', 'after_mock', 'before_response'
+      ]
+      stdout = test_result.stdout
+      lifecycle_hooks_output = stdout.split('{')[0]
+      assert lifecycle_hooks_output.strip() == "\n".join(expected_stdout)
 
 
 class TestRecordModifications():


### PR DESCRIPTION
## Branch Risk Review (`master...HEAD`)

### Findings (ordered by severity)

#### High – Mock mode now depends on replay policy + replay rewrites

`handle_request_mock` now always invokes replay request handling first. Replay request handling applies replay rewrite rules and `BEFORE_REPLAY` hooks when replay policy is enabled, so mock matching can now be changed by replay configuration. This is a cross-mode behavior change with regression risk for users expecting mock-only behavior.

```python
# stoobly_agent/app/proxy/handle_mock_service.py
def handle_request_mock(context: MockContext):
    handle_request_replay(ReplayContext(context.flow, context.intercept_settings))
    handle_request_mock_generic(
        context,
        failure=handle_mock_failure,
        success=handle_mock_success,
    )
```

```python
# stoobly_agent/app/proxy/handle_replay_service.py
policy = get_intercept_mode_policy(request, intercept_settings, mode.REPLAY)
if policy != replay_policy.NONE:
    if not options.get('no_rewrite'):
        __rewrite_request(replay_context)

    __replay_hook(lifecycle_hooks.BEFORE_REPLAY, replay_context)
```

#### Medium – `disable_transfer_encoding` may be bypassed when response is replaced

In `handle_response_test`, transfer encoding is disabled on the current response early. But in fallback, the code can replace `flow.response` with `mock_flow.response` from a copied flow. That replacement response may not preserve the prior normalization, creating potential transfer-encoding/content-length inconsistencies.

```python
# stoobly_agent/app/proxy/handle_test_service.py
disable_transfer_encoding(flow.response)
handle_response_replay(context)
```

```python
# stoobly_agent/app/proxy/handle_test_service.py
if not test_context or not test_context.test_results:
    # If mock policy is not NONE, return mock response
    # else we return live request response
    if _mock_policy != mock_policy.NONE:
        flow.response = mock_flow.response
```

---

### Overall Risk Assessment

- **Overall risk:** **Medium-High**
- **Primary risk driver:** Cross-mode coupling (`mock` behavior now influenced by `replay` settings/hooks).
- **Secondary risk driver:** Header/body consistency edge cases when replacing responses in test fallback paths.
- **Lower-risk changes:** Comment/test expectation updates and import cleanup appear aligned with intended behavior changes.

---

### Recommended Mitigations Before Merge

- Add/validate integration tests for:
  - mock mode with replay policy `none` vs enabled
  - mock matching with replay rewrite rules configured
  - test fallback path that returns mock response, asserting transfer-encoding/content-length invariants