### PR TITLE
Fix relative --app-dir-path not resolving lifecycle_hooks.py

### DIFF
--- a/stoobly_agent/config/data_dir.py
+++ b/stoobly_agent/config/data_dir.py
@@ -21,7 +21,7 @@ class DataDir:
             self.__path = path
 
             if path:
-                self.__data_dir_path = os.path.join(path, DATA_DIR_NAME)
+                self.__data_dir_path = os.path.join(os.path.abspath(path), DATA_DIR_NAME)
             else:
                 cwd = os.getcwd()
                 self.__data_dir_path = self.find_data_dir(cwd)

--- a/stoobly_agent/test/config/data_dir_test.py
+++ b/stoobly_agent/test/config/data_dir_test.py
@@ -78,3 +78,28 @@ class TestDataDir():
     finally:
       shutil.rmtree(temp_dir)
       os.chdir(original_cwd)
+
+  def test_relative_path_arg_returns_absolute_path(self, original_cwd: str):
+    """Regression: DataDir.instance() with a relative path must return an absolute .path"""
+    os.environ[ENV] = NONE
+    DataDir._instances = None
+
+    # Create parent/child dirs; we'll cd into child and pass '../' as path
+    temp_dir = os.path.join(original_cwd, 'tmp')
+    child_dir = os.path.join(temp_dir, 'child')
+    os.makedirs(child_dir, exist_ok=True)
+
+    expected_data_dir_path = os.path.join(temp_dir, DATA_DIR_NAME)
+
+    os.chdir(child_dir)
+
+    try:
+      result = DataDir.instance('..').path
+
+      assert os.path.isabs(result), f"Expected absolute path, got: {result}"
+      assert result == expected_data_dir_path
+
+    finally:
+      DataDir._instances = None
+      shutil.rmtree(temp_dir)
+      os.chdir(original_cwd)


### PR DESCRIPTION
## Summary

- Relative `--app-dir-path` values (e.g. `../..`) caused `lifecycle_hooks.py` to silently fail to load because the proxy subprocess resolved the relative path from a different working directory, producing a non-existent path
- Fix: `os.path.abspath()` in `DataDir.__init__` so `.path` is always absolute
  - Normalize path to absolute in DataDir.__init__ so .path is always absolute regardless of whether a relative path is passed via --app-dir-path.

## Test plan

- [x] New regression test `test_relative_path_arg_returns_absolute_path`
- [x] `poetry run pytest stoobly_agent/test/config/data_dir_test.py`

Closes: https://github.com/Stoobly/stoobly-agent/issues/733